### PR TITLE
Add Per-Namespace Permissions with Role Attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Add attributes to any client role using the format:
 | ```registry:myrepo``` | ```pull,push``` | Pull and push access to myrepo namespace |
 | ```registry:myrepo``` | ```pull,push,delete``` | Full access to myrepo namespace |
 | ```registry:myrepo``` | ```*``` | Full access (expands to pull,push,delete) |
+| ```registry``` | ```catalog``` | Grants catalog access regardless of REGISTRY_CATALOG_AUDIENCE |
 
 ### How Role Attributes Combine with Groups
 
@@ -161,6 +162,17 @@ Create a role "project-alpha" with multiple attributes:
 - ```registry:shared-libs``` = ```pull```
 
 Result: Assign this single role to grant access to all project namespaces with appropriate permissions.
+
+**Use Case 4: Grant catalog access to specific users without changing global settings**
+
+By default, ```REGISTRY_CATALOG_AUDIENCE``` is set to ```admin```, meaning only admins can list repositories.
+To grant catalog access to specific users or roles without changing the global setting:
+
+Solution: Create a role with attribute:
+- Key: ```registry```
+- Value: ```catalog```
+
+Result: Users with this role can access the registry catalog (list repositories), while other non-admin users remain restricted.
 
 - - -
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![GitHub](https://img.shields.io/badge/keycloak-26.4.0-orange)
 ![GitHub](https://img.shields.io/badge/registry-2.8.2-orange)
 ![GitHub](https://img.shields.io/github/license/alexanderwolz/keycloak-registry-mapper)
-![GitHub](https://img.shields.io/badge/test_cases-632-informational)
+![GitHub](https://img.shields.io/badge/test_cases-657-informational)
 ![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/alexanderwolz/keycloak-registry-mapper)
 ![GitHub all releases](https://img.shields.io/github/downloads/alexanderwolz/keycloak-registry-mapper/total?color=informational)
 
@@ -30,6 +30,7 @@ Alternatively use a pre-built Keycloak Docker [image](https://hub.docker.com/r/a
 - Assigning the client role ```admin``` will allow access to any resource in the whole registry and give full access.
 - Users could be grouped to domain-namespaces according to their email-addresses  (can be configured via environment variables, default off)
 - Without having any roles and groups assigned, users will have full access to the namespace if it matches their username (can be configured via environment variables, default off)
+- **Role attributes** can be used to grant per-namespace permissions without requiring group membership (see below)
 
 ## ⚙️ Configuration
 This mapper supports following environment variables (either set on server or in docker container):
@@ -93,6 +94,73 @@ Keycloak must be setup to have a docker-v2 registry client, roles and optional g
 6. Now the user will have access to registry namespace *myregistry.com/mycompany/*
 
 ![Keycloak Registry Client Config](assets/keycloak-config/assign_role_and_group_to_user.gif)
+
+## 🎯 Per-Namespace Permissions with Role Attributes
+
+Role attributes allow you to define fine-grained, per-namespace permissions directly on client roles. This is useful when users need different permission levels for different namespaces.
+
+### Role Attribute Format
+
+Add attributes to any client role using the format:
+- **Key:** ```registry:{namespace}```
+- **Value:** ```pull```, ```push```, ```delete```, or ```*``` (comma-separated for multiple actions)
+
+| Attribute Key | Attribute Value | Result |
+|---------------|-----------------|--------|
+| ```registry:myrepo``` | ```pull``` | Pull-only access to myrepo namespace |
+| ```registry:myrepo``` | ```pull,push``` | Pull and push access to myrepo namespace |
+| ```registry:myrepo``` | ```pull,push,delete``` | Full access to myrepo namespace |
+| ```registry:myrepo``` | ```*``` | Full access (expands to pull,push,delete) |
+
+### How Role Attributes Combine with Groups
+
+| Access Method | Permissions |
+|---------------|-------------|
+| Group membership only | pull (read-only by default) |
+| Group + ```editor``` role | pull, push, delete |
+| Group + role attribute | Group permissions + attribute permissions (combined) |
+| Role attribute only (no group) | Exactly what's specified in the attribute |
+
+### Setup Role Attributes in Keycloak
+
+1. Go to your realm and choose "Clients" section
+2. Select your registry client (e.g., "myregistry")
+3. Go to "Roles" tab
+4. Create a new role or select an existing one
+5. Go to the "Attributes" tab
+6. Add attributes with key ```registry:{namespace}``` and value as the allowed actions
+
+### Example Use Cases
+
+**Use Case 1: User needs push access to one specific namespace**
+
+User is member of groups ```registry-repository-1``` and ```registry-repository-2``` (pull-only by default).
+User needs push access to ```repository-1``` but not ```repository-2```.
+
+Solution: Create a role with attribute:
+- Key: ```registry:repository-1```
+- Value: ```push```
+
+Result: User gets pull from both repos (via groups), plus push to repository-1 (via attribute).
+
+**Use Case 2: User needs access to a namespace without group membership**
+
+User needs pull,push access to ```repository-3``` but should not be added to any group.
+
+Solution: Create a role with attribute:
+- Key: ```registry:repository-3```
+- Value: ```pull,push```
+
+Result: User gets pull,push access to repository-3 directly via the role attribute.
+
+**Use Case 3: Create a project role that bundles multiple namespace permissions**
+
+Create a role "project-alpha" with multiple attributes:
+- ```registry:project-frontend``` = ```pull,push,delete```
+- ```registry:project-backend``` = ```pull,push,delete```
+- ```registry:shared-libs``` = ```pull```
+
+Result: Assign this single role to grant access to all project namespaces with appropriate permissions.
 
 - - -
 

--- a/src/main/kotlin/de/alexanderwolz/keycloak/registry/mapper/AbstractDockerScopeMapper.kt
+++ b/src/main/kotlin/de/alexanderwolz/keycloak/registry/mapper/AbstractDockerScopeMapper.kt
@@ -75,6 +75,13 @@ abstract class AbstractDockerScopeMapper(
             .also { logger.debug { "User has client roles: ${it.joinToString()}" } }
     }
 
+    internal fun getClientRoles(user: UserModel, client: ClientModel): Collection<RoleModel> {
+        return RoleUtils.getDeepUserRoleMappings(user)
+            .filter { it.container is ClientModel && it.container.id == client.id }
+            .distinct()
+            .also { roles -> logger.debug { "User has client roles: ${roles.map { it.name }.joinToString()}" } }
+    }
+
     internal fun getDomainFromEmail(email: String): String? {
         val parts = email.split("@")
         if (parts.size == 2) {

--- a/src/main/kotlin/de/alexanderwolz/keycloak/registry/mapper/KeycloakGroupsAndRolesToDockerScopeMapper.kt
+++ b/src/main/kotlin/de/alexanderwolz/keycloak/registry/mapper/KeycloakGroupsAndRolesToDockerScopeMapper.kt
@@ -41,6 +41,10 @@ class KeycloakGroupsAndRolesToDockerScopeMapper : AbstractDockerScopeMapper(
 
         // Role attribute prefix for namespace permissions (e.g., "registry:myrepo" = "pull,push")
         internal const val ROLE_ATTRIBUTE_PREFIX = "registry:"
+
+        // Role attribute key and value for catalog access (key: "registry", value: "catalog")
+        internal const val ROLE_ATTRIBUTE_KEY_REGISTRY = "registry"
+        internal const val ROLE_ATTRIBUTE_VALUE_CATALOG = "catalog"
     }
 
     internal var groupPrefix = getGroupPrefixFromEnv()
@@ -93,7 +97,7 @@ class KeycloakGroupsAndRolesToDockerScopeMapper : AbstractDockerScopeMapper(
 
         //users and editors
         if (accessItem.type == ACCESS_TYPE_REGISTRY) {
-            return handleRegistryAccess(responseToken, clientRoleNames, accessItem, user)
+            return handleRegistryAccess(responseToken, clientRoleNames, clientRoles, accessItem, user)
         }
 
         if (accessItem.type == ACCESS_TYPE_REPOSITORY) {
@@ -111,24 +115,45 @@ class KeycloakGroupsAndRolesToDockerScopeMapper : AbstractDockerScopeMapper(
     private fun handleRegistryAccess(
         responseToken: DockerResponseToken,
         clientRoleNames: Collection<String>,
+        clientRoles: Collection<RoleModel>,
         accessItem: DockerScopeAccess,
         user: UserModel
     ): DockerResponseToken {
         if (accessItem.name == NAME_CATALOG) {
+            // Check role attributes first
+            if (hasCatalogAccessFromRoleAttributes(clientRoles)) {
+                return allowAll(responseToken, accessItem, user, "Catalog access via role attribute")
+            }
+            // Then check global catalogAudience
             if (isAllowedToAccessRegistryCatalogScope(clientRoleNames)) {
                 val reason = "Allowed by catalog audience '$catalogAudience'"
                 return allowAll(responseToken, accessItem, user, reason)
             }
             val reason = if (clientRoleNames.contains(ROLE_EDITOR)) {
-                "Role '$ROLE_ADMIN' or \$${KEY_REGISTRY_CATALOG_AUDIENCE}='$AUDIENCE_EDITOR' needed to access catalog"
+                "Role '$ROLE_ADMIN' or \$${KEY_REGISTRY_CATALOG_AUDIENCE}='$AUDIENCE_EDITOR' or role attribute '$ROLE_ATTRIBUTE_KEY_REGISTRY'='$ROLE_ATTRIBUTE_VALUE_CATALOG' needed to access catalog"
             } else {
-                "Role '$ROLE_ADMIN' or \$${KEY_REGISTRY_CATALOG_AUDIENCE}='$AUDIENCE_USER' needed to access catalog"
+                "Role '$ROLE_ADMIN' or \$${KEY_REGISTRY_CATALOG_AUDIENCE}='$AUDIENCE_USER' or role attribute '$ROLE_ATTRIBUTE_KEY_REGISTRY'='$ROLE_ATTRIBUTE_VALUE_CATALOG' needed to access catalog"
             }
             return deny(responseToken, accessItem, user, reason)
         }
         //only admins can access scope 'registry'
         val reason = "Role '$ROLE_ADMIN' needed to access registry scope"
         return deny(responseToken, accessItem, user, reason)
+    }
+
+    /**
+     * Checks if any of the user's roles have the catalog access attribute.
+     * The attribute key is "registry" and the value must be "catalog".
+     */
+    internal fun hasCatalogAccessFromRoleAttributes(clientRoles: Collection<RoleModel>): Boolean {
+        for (role in clientRoles) {
+            val attributeValues = role.getAttributeStream(ROLE_ATTRIBUTE_KEY_REGISTRY).toList()
+            if (attributeValues.any { it.lowercase() == ROLE_ATTRIBUTE_VALUE_CATALOG }) {
+                logger.debug { "Role '${role.name}' grants catalog access via attribute" }
+                return true
+            }
+        }
+        return false
     }
 
     private fun isAllowedToAccessRegistryCatalogScope(clientRoleNames: Collection<String>): Boolean {

--- a/src/main/kotlin/de/alexanderwolz/keycloak/registry/mapper/KeycloakGroupsAndRolesToDockerScopeMapper.kt
+++ b/src/main/kotlin/de/alexanderwolz/keycloak/registry/mapper/KeycloakGroupsAndRolesToDockerScopeMapper.kt
@@ -38,6 +38,9 @@ class KeycloakGroupsAndRolesToDockerScopeMapper : AbstractDockerScopeMapper(
         internal const val NAMESPACE_SCOPE_DOMAIN = "domain"
         internal const val NAMESPACE_SCOPE_SLD = "sld"
         internal val NAMESPACE_SCOPE_DEFAULT = setOf(NAMESPACE_SCOPE_GROUP)
+
+        // Role attribute prefix for namespace permissions (e.g., "registry:myrepo" = "pull,push")
+        internal const val ROLE_ATTRIBUTE_PREFIX = "registry:"
     }
 
     internal var groupPrefix = getGroupPrefixFromEnv()
@@ -68,15 +71,17 @@ class KeycloakGroupsAndRolesToDockerScopeMapper : AbstractDockerScopeMapper(
             return responseToken // no actions given in scope
         }
 
-        val clientRoleNames = getClientRoleNames(userSession.user, clientSession.client)
+        val clientRoles = getClientRoles(userSession.user, clientSession.client)
+        val clientRoleNames = clientRoles.map { it.name }
 
-        return handleScopeAccess(responseToken, accessItems.first(), clientRoleNames, userSession.user)
+        return handleScopeAccess(responseToken, accessItems.first(), clientRoleNames, clientRoles, userSession.user)
     }
 
     private fun handleScopeAccess(
         responseToken: DockerResponseToken,
         accessItem: DockerScopeAccess,
         clientRoleNames: Collection<String>,
+        clientRoles: Collection<RoleModel>,
         user: UserModel,
     ): DockerResponseToken {
 
@@ -92,12 +97,12 @@ class KeycloakGroupsAndRolesToDockerScopeMapper : AbstractDockerScopeMapper(
         }
 
         if (accessItem.type == ACCESS_TYPE_REPOSITORY) {
-            return handleRepositoryAccess(responseToken, clientRoleNames, accessItem, user)
+            return handleRepositoryAccess(responseToken, clientRoleNames, clientRoles, accessItem, user)
         }
 
         if (accessItem.type == ACCESS_TYPE_REPOSITORY_PLUGIN) {
             //handle plugins the same as normal repositories
-            return handleRepositoryAccess(responseToken, clientRoleNames, accessItem, user)
+            return handleRepositoryAccess(responseToken, clientRoleNames, clientRoles, accessItem, user)
         }
 
         return deny(responseToken, accessItem, user, "Unsupported access type '${accessItem.type}'")
@@ -135,6 +140,7 @@ class KeycloakGroupsAndRolesToDockerScopeMapper : AbstractDockerScopeMapper(
     private fun handleRepositoryAccess(
         responseToken: DockerResponseToken,
         clientRoleNames: Collection<String>,
+        clientRoles: Collection<RoleModel>,
         accessItem: DockerScopeAccess,
         user: UserModel
     ): DockerResponseToken {
@@ -143,6 +149,9 @@ class KeycloakGroupsAndRolesToDockerScopeMapper : AbstractDockerScopeMapper(
             responseToken, accessItem, user, "Role '$ROLE_ADMIN' needed to access default namespace repositories"
         )
 
+        // Check for namespace-specific actions from role attributes
+        val roleAttributeActions = getNamespaceActionsFromRoleAttributes(clientRoles, namespace)
+
         if (namespaceScope.contains(NAMESPACE_SCOPE_USERNAME) && isUsernameRepository(namespace, user.username)) {
             //user's own repository, will have all access
             val allowedActions = substituteRequestedActions(accessItem.actions)
@@ -150,29 +159,159 @@ class KeycloakGroupsAndRolesToDockerScopeMapper : AbstractDockerScopeMapper(
         }
 
         if (namespaceScope.contains(NAMESPACE_SCOPE_DOMAIN) && isDomainRepository(namespace, user.email)) {
-            return handleNamespaceRepositoryAccess(responseToken, accessItem, clientRoleNames, user)
+            return handleNamespaceRepositoryAccessWithAttributes(
+                responseToken, accessItem, clientRoleNames, roleAttributeActions, user, "domain match"
+            )
         }
 
         if (namespaceScope.contains(NAMESPACE_SCOPE_SLD) && isSecondLevelDomainRepository(namespace, user.email)) {
-            return handleNamespaceRepositoryAccess(responseToken, accessItem, clientRoleNames, user)
+            return handleNamespaceRepositoryAccessWithAttributes(
+                responseToken, accessItem, clientRoleNames, roleAttributeActions, user, "SLD match"
+            )
         }
 
         if (namespaceScope.contains(NAMESPACE_SCOPE_GROUP)) {
-            val namespacesFromGroups = getUserNamespacesFromGroups(user).also {
-                if (it.isEmpty()) {
-                    val reason = "User does not belong to any namespace - check groups"
-                    return deny(responseToken, accessItem, user, reason)
-                }
-            }
+            val namespacesFromGroups = getUserNamespacesFromGroups(user)
             if (namespacesFromGroups.contains(namespace)) {
-                return handleNamespaceRepositoryAccess(responseToken, accessItem, clientRoleNames, user)
+                return handleNamespaceRepositoryAccessWithAttributes(
+                    responseToken, accessItem, clientRoleNames, roleAttributeActions, user, "group membership"
+                )
             }
-            val reason = "Missing namespace group '$groupPrefix$namespace' - check groups"
+            // If not in group but has role attribute actions, grant access via role attribute
+            if (roleAttributeActions != null) {
+                return handleNamespaceRepositoryAccessByAttributeOnly(
+                    responseToken, accessItem, roleAttributeActions, user, namespace
+                )
+            }
+            if (namespacesFromGroups.isEmpty()) {
+                val reason = "User does not belong to any namespace - check groups or role attributes"
+                return deny(responseToken, accessItem, user, reason)
+            }
+            val reason = "Missing namespace group '$groupPrefix$namespace' or role attribute '$ROLE_ATTRIBUTE_PREFIX$namespace'"
             return deny(responseToken, accessItem, user, reason)
         }
 
-        val reason = "User does not belong to namespace '$namespace' either by group nor username nor domain"
+        // If no namespace scope is configured but user has role attribute actions
+        if (roleAttributeActions != null) {
+            return handleNamespaceRepositoryAccessByAttributeOnly(
+                responseToken, accessItem, roleAttributeActions, user, namespace
+            )
+        }
+
+        val reason = "User does not belong to namespace '$namespace' - check groups, username, domain, or role attributes"
         return deny(responseToken, accessItem, user, reason)
+    }
+
+    /**
+     * Handles namespace repository access combining global roles with role attribute actions.
+     */
+    private fun handleNamespaceRepositoryAccessWithAttributes(
+        responseToken: DockerResponseToken,
+        accessItem: DockerScopeAccess,
+        clientRoleNames: Collection<String>,
+        roleAttributeActions: Set<String>?,
+        user: UserModel,
+        accessReason: String
+    ): DockerResponseToken {
+        val requestedActions = substituteRequestedActions(accessItem.actions)
+
+        // Get allowed actions from global roles
+        val roleBasedActions = filterAllowedActions(requestedActions, clientRoleNames)
+
+        // Combine with role attribute actions (if any)
+        val allowedActions = if (roleAttributeActions != null) {
+            val attributeBasedActions = filterActionsByRoleAttribute(requestedActions, roleAttributeActions)
+            (roleBasedActions + attributeBasedActions).distinct()
+        } else {
+            roleBasedActions
+        }
+
+        if (allowedActions.isEmpty()) {
+            val reason = "Missing privileges for actions [${accessItem.actions.joinToString()}] via $accessReason - check client roles or role attributes"
+            return deny(responseToken, accessItem, user, reason)
+        }
+
+        if (hasAllPrivileges(allowedActions, requestedActions)) {
+            val reason = "User has privilege on all actions via $accessReason"
+            return allowWithActions(responseToken, accessItem, allowedActions, user, reason)
+        }
+
+        val reason = "User has privilege only on [${allowedActions.joinToString()}] via $accessReason"
+        return allowWithActions(responseToken, accessItem, allowedActions, user, reason)
+    }
+
+    /**
+     * Handles namespace repository access when access is granted solely by role attributes (no group membership).
+     */
+    private fun handleNamespaceRepositoryAccessByAttributeOnly(
+        responseToken: DockerResponseToken,
+        accessItem: DockerScopeAccess,
+        roleAttributeActions: Set<String>,
+        user: UserModel,
+        namespace: String
+    ): DockerResponseToken {
+        val requestedActions = substituteRequestedActions(accessItem.actions)
+        val allowedActions = filterActionsByRoleAttribute(requestedActions, roleAttributeActions)
+
+        if (allowedActions.isEmpty()) {
+            val reason = "Missing privileges for actions [${accessItem.actions.joinToString()}] via role attribute '$ROLE_ATTRIBUTE_PREFIX$namespace'"
+            return deny(responseToken, accessItem, user, reason)
+        }
+
+        val accessReason = "role attribute '$ROLE_ATTRIBUTE_PREFIX$namespace'"
+        if (hasAllPrivileges(allowedActions, requestedActions)) {
+            val reason = "User has privilege on all actions via $accessReason"
+            return allowWithActions(responseToken, accessItem, allowedActions, user, reason)
+        }
+
+        val reason = "User has privilege only on [${allowedActions.joinToString()}] via $accessReason"
+        return allowWithActions(responseToken, accessItem, allowedActions, user, reason)
+    }
+
+    /**
+     * Gets the allowed actions for a namespace from role attributes.
+     * Looks for attributes like "registry:namespace" = "pull,push" or "registry:namespace" = "*"
+     * Supported actions: pull, push, delete, * (expands to all actions)
+     * Returns the set of allowed actions, or null if no attribute found.
+     */
+    internal fun getNamespaceActionsFromRoleAttributes(clientRoles: Collection<RoleModel>, namespace: String): Set<String>? {
+        val attributeKey = "$ROLE_ATTRIBUTE_PREFIX$namespace"
+        val allowedActions = mutableSetOf<String>()
+
+        for (role in clientRoles) {
+            val attributeValues = role.getAttributeStream(attributeKey).toList()
+            for (value in attributeValues) {
+                val actions = value.lowercase().split(",").map { it.trim() }
+                for (action in actions) {
+                    when (action) {
+                        ACTION_ALL, "*" -> {
+                            // Expand * to all actions
+                            allowedActions.addAll(ACTION_ALL_SUBSTITUTE)
+                        }
+                        ACTION_PULL, ACTION_PUSH, ACTION_DELETE -> {
+                            allowedActions.add(action)
+                        }
+                    }
+                }
+            }
+        }
+
+        return if (allowedActions.isNotEmpty()) {
+            logger.debug { "Found role attribute actions for namespace '$namespace': ${allowedActions.joinToString()}" }
+            allowedActions
+        } else {
+            null
+        }
+    }
+
+    /**
+     * Filters requested actions based on role attribute allowed actions.
+     */
+    internal fun filterActionsByRoleAttribute(
+        requestedActions: Collection<String>,
+        allowedActions: Set<String>
+    ): List<String> {
+        return requestedActions.filter { allowedActions.contains(it) }
     }
 
     internal fun getUserNamespacesFromGroups(user: UserModel): Collection<String> {
@@ -181,30 +320,6 @@ class KeycloakGroupsAndRolesToDockerScopeMapper : AbstractDockerScopeMapper(
         val filteredGroups = allGroups.filter { it.name.lowercase().startsWith(groupPrefix) }
         val namespaces = filteredGroups.map { it.name.lowercase().replace(groupPrefix, "") }
         return namespaces.toList()
-    }
-
-    private fun handleNamespaceRepositoryAccess(
-        responseToken: DockerResponseToken,
-        accessItem: DockerScopeAccess,
-        clientRoleNames: Collection<String>,
-        user: UserModel
-    ): DockerResponseToken {
-
-        val requestedActions = substituteRequestedActions(accessItem.actions)
-        val allowedActions = filterAllowedActions(requestedActions, clientRoleNames)
-
-        if (allowedActions.isEmpty()) {
-            val reason = "Missing privileges for actions [${accessItem.actions.joinToString()}] - check client roles"
-            return deny(responseToken, accessItem, user, reason)
-        }
-
-        if (hasAllPrivileges(allowedActions, requestedActions)) {
-            val reason = "User has privilege on all actions"
-            return allowWithActions(responseToken, accessItem, allowedActions, user, reason)
-        }
-
-        val reason = "User has privilege only on [${allowedActions.joinToString()}]"
-        return allowWithActions(responseToken, accessItem, allowedActions, user, reason)
     }
 
     internal fun filterAllowedActions(

--- a/src/test/kotlin/de/alexanderwolz/keycloak/registry/mapper/testsuite/AbstractScopeMapperTestSuite.kt
+++ b/src/test/kotlin/de/alexanderwolz/keycloak/registry/mapper/testsuite/AbstractScopeMapperTestSuite.kt
@@ -136,6 +136,18 @@ abstract class AbstractScopeMapperTestSuite {
         given(userModel.roleMappingsStream).willAnswer { roles.stream() }
     }
 
+    /**
+     * Sets roles with optional attributes.
+     * Each entry is a Pair of (roleName, Map of attributeKey to attributeValue)
+     * Example: setRolesWithAttributes("myrole" to mapOf("registry:unchained" to "editor"))
+     */
+    protected fun setRolesWithAttributes(vararg roleConfigs: Pair<String, Map<String, String>>) {
+        val roles = roleConfigs.map { (roleName, attributes) ->
+            createClientRoleWithAttributes(roleName, attributes)
+        }
+        given(userModel.roleMappingsStream).willAnswer { roles.stream() }
+    }
+
     protected fun setScope(scope: String = "") {
         val actualScope = scope.ifEmpty { null }
         given(clientSession.getNote(DockerAuthV2Protocol.SCOPE_PARAM)).willReturn(actualScope)
@@ -185,13 +197,27 @@ abstract class AbstractScopeMapperTestSuite {
 
     private fun createClientRolesByNames(vararg names: String): Collection<RoleModel> {
         return names.map { roleName ->
-            val role = Mockito.mock(RoleModel::class.java)
-            val container = Mockito.mock(ClientModel::class.java)
-            given(container.id).willReturn(CLIENT_ID)
-            given(role.name).willReturn(roleName)
-            given(role.container).willReturn(container)
-            role
+            createClientRoleWithAttributes(roleName, emptyMap())
         }
+    }
+
+    private fun createClientRoleWithAttributes(roleName: String, attributes: Map<String, String>): RoleModel {
+        val role = Mockito.mock(RoleModel::class.java)
+        val container = Mockito.mock(ClientModel::class.java)
+        given(container.id).willReturn(CLIENT_ID)
+        given(role.name).willReturn(roleName)
+        given(role.container).willReturn(container)
+        // Mock getAttributeStream to return the attribute value for matching keys
+        BDDMockito.given(role.getAttributeStream(Mockito.anyString())).willAnswer { invocation ->
+            val key = invocation.getArgument<String>(0)
+            val value = attributes[key]
+            if (value != null) {
+                java.util.stream.Stream.of(value)
+            } else {
+                java.util.stream.Stream.empty<String>()
+            }
+        }
+        return role
     }
 
 }

--- a/src/test/kotlin/de/alexanderwolz/keycloak/registry/mapper/testsuite/RoleAttributesTestSuite.kt
+++ b/src/test/kotlin/de/alexanderwolz/keycloak/registry/mapper/testsuite/RoleAttributesTestSuite.kt
@@ -1,10 +1,16 @@
 package de.alexanderwolz.keycloak.registry.mapper.testsuite
 
+import de.alexanderwolz.keycloak.registry.mapper.AbstractDockerScopeMapper.Companion.ACTION_ALL
 import de.alexanderwolz.keycloak.registry.mapper.AbstractDockerScopeMapper.Companion.ACTION_DELETE
 import de.alexanderwolz.keycloak.registry.mapper.AbstractDockerScopeMapper.Companion.ACTION_PULL
 import de.alexanderwolz.keycloak.registry.mapper.AbstractDockerScopeMapper.Companion.ACTION_PUSH
+import de.alexanderwolz.keycloak.registry.mapper.KeycloakGroupsAndRolesToDockerScopeMapper.Companion.AUDIENCE_ADMIN
+import de.alexanderwolz.keycloak.registry.mapper.KeycloakGroupsAndRolesToDockerScopeMapper.Companion.AUDIENCE_EDITOR
+import de.alexanderwolz.keycloak.registry.mapper.KeycloakGroupsAndRolesToDockerScopeMapper.Companion.AUDIENCE_USER
 import de.alexanderwolz.keycloak.registry.mapper.KeycloakGroupsAndRolesToDockerScopeMapper.Companion.NAMESPACE_SCOPE_GROUP
+import de.alexanderwolz.keycloak.registry.mapper.KeycloakGroupsAndRolesToDockerScopeMapper.Companion.ROLE_ATTRIBUTE_KEY_REGISTRY
 import de.alexanderwolz.keycloak.registry.mapper.KeycloakGroupsAndRolesToDockerScopeMapper.Companion.ROLE_ATTRIBUTE_PREFIX
+import de.alexanderwolz.keycloak.registry.mapper.KeycloakGroupsAndRolesToDockerScopeMapper.Companion.ROLE_ATTRIBUTE_VALUE_CATALOG
 import de.alexanderwolz.keycloak.registry.mapper.KeycloakGroupsAndRolesToDockerScopeMapper.Companion.ROLE_EDITOR
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -52,6 +58,9 @@ class RoleAttributesTestSuite : AbstractScopeMapperTestSuite() {
         private const val ATTR_REPO1 = "${ROLE_ATTRIBUTE_PREFIX}$NAMESPACE_REPO1"
         private const val ATTR_REPO2 = "${ROLE_ATTRIBUTE_PREFIX}$NAMESPACE_REPO2"
         private const val ATTR_REPO3 = "${ROLE_ATTRIBUTE_PREFIX}$NAMESPACE_REPO3"
+
+        // Catalog scope
+        const val SCOPE_CATALOG = "registry:catalog:*"
     }
 
     @Nested
@@ -395,6 +404,146 @@ class RoleAttributesTestSuite : AbstractScopeMapperTestSuite() {
             )
             setScope(SCOPE_REPO1_PULL_PUSH)
             assertContainsOneAccessItemWithActions(ACTION_PULL, ACTION_PUSH)
+        }
+    }
+
+    /**
+     * Tests for catalog access via role attributes.
+     *
+     * The attribute key "registry" with value "catalog" grants catalog access
+     * regardless of the global REGISTRY_CATALOG_AUDIENCE setting.
+     */
+    @Nested
+    inner class CatalogAccessViaAttributeTests {
+
+        @Test
+        internal fun user_with_catalog_attribute_gets_catalog_access_when_audience_is_admin() {
+            // User has no special role, but has catalog attribute
+            // REGISTRY_CATALOG_AUDIENCE defaults to admin, so normally denied
+            setAudience(AUDIENCE_ADMIN)
+            setRolesWithAttributes(
+                "catalog-role" to mapOf(ROLE_ATTRIBUTE_KEY_REGISTRY to ROLE_ATTRIBUTE_VALUE_CATALOG)
+            )
+            setScope(SCOPE_CATALOG)
+            assertContainsOneAccessItemWithActions(ACTION_ALL)
+        }
+
+        @Test
+        internal fun editor_with_catalog_attribute_gets_catalog_access_when_audience_is_admin() {
+            // Editor would normally be denied when audience=admin
+            setAudience(AUDIENCE_ADMIN)
+            setRolesWithAttributes(
+                ROLE_EDITOR to emptyMap(),
+                "catalog-role" to mapOf(ROLE_ATTRIBUTE_KEY_REGISTRY to ROLE_ATTRIBUTE_VALUE_CATALOG)
+            )
+            setScope(SCOPE_CATALOG)
+            assertContainsOneAccessItemWithActions(ACTION_ALL)
+        }
+
+        @Test
+        internal fun user_without_catalog_attribute_denied_when_audience_is_admin() {
+            // User has a role but no catalog attribute - should be denied
+            setAudience(AUDIENCE_ADMIN)
+            setRolesWithAttributes(
+                "some-role" to mapOf(ATTR_REPO1 to "pull,push")
+            )
+            setScope(SCOPE_CATALOG)
+            assertEmptyAccessItems()
+        }
+
+        @Test
+        internal fun editor_without_catalog_attribute_denied_when_audience_is_admin() {
+            // Editor has no catalog attribute and audience=admin - should be denied
+            setAudience(AUDIENCE_ADMIN)
+            setRoles(ROLE_EDITOR)
+            setScope(SCOPE_CATALOG)
+            assertEmptyAccessItems()
+        }
+
+        @Test
+        internal fun editor_without_catalog_attribute_allowed_when_audience_is_editor() {
+            // Editor should be allowed via audience setting
+            setAudience(AUDIENCE_EDITOR)
+            setRoles(ROLE_EDITOR)
+            setScope(SCOPE_CATALOG)
+            assertContainsOneAccessItemWithActions(ACTION_ALL)
+        }
+
+        @Test
+        internal fun user_without_catalog_attribute_allowed_when_audience_is_user() {
+            // Any user should be allowed when audience=user
+            setAudience(AUDIENCE_USER)
+            setRolesWithAttributes(
+                "some-role" to emptyMap()
+            )
+            setScope(SCOPE_CATALOG)
+            assertContainsOneAccessItemWithActions(ACTION_ALL)
+        }
+
+        @Test
+        internal fun catalog_attribute_case_insensitive() {
+            // Value check should be case-insensitive
+            setAudience(AUDIENCE_ADMIN)
+            setRolesWithAttributes(
+                "catalog-role" to mapOf(ROLE_ATTRIBUTE_KEY_REGISTRY to "CATALOG")
+            )
+            setScope(SCOPE_CATALOG)
+            assertContainsOneAccessItemWithActions(ACTION_ALL)
+        }
+
+        @Test
+        internal fun wrong_attribute_value_denied() {
+            // Key is "registry" but value is NOT "catalog" - should be denied
+            setAudience(AUDIENCE_ADMIN)
+            setRolesWithAttributes(
+                "wrong-value-role" to mapOf(ROLE_ATTRIBUTE_KEY_REGISTRY to "something_else")
+            )
+            setScope(SCOPE_CATALOG)
+            assertEmptyAccessItems()
+        }
+
+        @Test
+        internal fun multiple_roles_one_with_catalog_attribute() {
+            // User has multiple roles, only one grants catalog access
+            setAudience(AUDIENCE_ADMIN)
+            setRolesWithAttributes(
+                "namespace-role" to mapOf(ATTR_REPO1 to "pull,push"),
+                "catalog-role" to mapOf(ROLE_ATTRIBUTE_KEY_REGISTRY to ROLE_ATTRIBUTE_VALUE_CATALOG)
+            )
+            setScope(SCOPE_CATALOG)
+            assertContainsOneAccessItemWithActions(ACTION_ALL)
+        }
+
+        @Test
+        internal fun catalog_attribute_combined_with_namespace_attribute() {
+            // User has both catalog access and namespace permissions via attributes
+            setAudience(AUDIENCE_ADMIN)
+            setNamespaceScope(NAMESPACE_SCOPE_GROUP)
+            setRolesWithAttributes(
+                "multi-access-role" to mapOf(
+                    ROLE_ATTRIBUTE_KEY_REGISTRY to ROLE_ATTRIBUTE_VALUE_CATALOG,
+                    ATTR_REPO1 to "pull,push"
+                )
+            )
+            // Can access catalog
+            setScope(SCOPE_CATALOG)
+            assertContainsOneAccessItemWithActions(ACTION_ALL)
+        }
+
+        @Test
+        internal fun catalog_attribute_combined_with_namespace_attribute_can_push() {
+            // Same user from above can also push to the namespace
+            setAudience(AUDIENCE_ADMIN)
+            setNamespaceScope(NAMESPACE_SCOPE_GROUP)
+            setRolesWithAttributes(
+                "multi-access-role" to mapOf(
+                    ROLE_ATTRIBUTE_KEY_REGISTRY to ROLE_ATTRIBUTE_VALUE_CATALOG,
+                    ATTR_REPO1 to "pull,push"
+                )
+            )
+            // Can also push to repository-1
+            setScope(SCOPE_REPO1_PUSH)
+            assertContainsOneAccessItemWithActions(ACTION_PUSH)
         }
     }
 }

--- a/src/test/kotlin/de/alexanderwolz/keycloak/registry/mapper/testsuite/RoleAttributesTestSuite.kt
+++ b/src/test/kotlin/de/alexanderwolz/keycloak/registry/mapper/testsuite/RoleAttributesTestSuite.kt
@@ -1,0 +1,400 @@
+package de.alexanderwolz.keycloak.registry.mapper.testsuite
+
+import de.alexanderwolz.keycloak.registry.mapper.AbstractDockerScopeMapper.Companion.ACTION_DELETE
+import de.alexanderwolz.keycloak.registry.mapper.AbstractDockerScopeMapper.Companion.ACTION_PULL
+import de.alexanderwolz.keycloak.registry.mapper.AbstractDockerScopeMapper.Companion.ACTION_PUSH
+import de.alexanderwolz.keycloak.registry.mapper.KeycloakGroupsAndRolesToDockerScopeMapper.Companion.NAMESPACE_SCOPE_GROUP
+import de.alexanderwolz.keycloak.registry.mapper.KeycloakGroupsAndRolesToDockerScopeMapper.Companion.ROLE_ATTRIBUTE_PREFIX
+import de.alexanderwolz.keycloak.registry.mapper.KeycloakGroupsAndRolesToDockerScopeMapper.Companion.ROLE_EDITOR
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for role attribute-based namespace permissions.
+ *
+ * Role attributes allow defining per-namespace permissions directly on roles.
+ * Format: "registry:{namespace}" = "pull,push,delete" or "registry:{namespace}" = "*"
+ *
+ * Supported actions: pull, push, delete, * (expands to all actions)
+ *
+ * This test suite verifies:
+ * - Role attributes grant access to namespaces (even without group membership)
+ * - Role attributes define specific allowed actions for namespaces
+ * - Role attributes combine with group-based access and global roles
+ * - Multiple roles with different namespace permissions work correctly
+ */
+class RoleAttributesTestSuite : AbstractScopeMapperTestSuite() {
+
+    companion object {
+        private const val NAMESPACE_REPO1 = "repository-1"
+        private const val NAMESPACE_REPO2 = "repository-2"
+        private const val NAMESPACE_REPO3 = "repository-3"
+        private const val IMAGE = "image"
+
+        private const val GROUP_REPO1 = "registry-$NAMESPACE_REPO1"
+        private const val GROUP_REPO2 = "registry-$NAMESPACE_REPO2"
+
+        const val SCOPE_REPO1_ALL = "repository:$NAMESPACE_REPO1/$IMAGE:*"
+        const val SCOPE_REPO1_PULL = "repository:$NAMESPACE_REPO1/$IMAGE:pull"
+        const val SCOPE_REPO1_PUSH = "repository:$NAMESPACE_REPO1/$IMAGE:push"
+        const val SCOPE_REPO1_DELETE = "repository:$NAMESPACE_REPO1/$IMAGE:delete"
+        const val SCOPE_REPO1_PULL_PUSH = "repository:$NAMESPACE_REPO1/$IMAGE:pull,push"
+
+        const val SCOPE_REPO2_ALL = "repository:$NAMESPACE_REPO2/$IMAGE:*"
+        const val SCOPE_REPO2_PULL = "repository:$NAMESPACE_REPO2/$IMAGE:pull"
+        const val SCOPE_REPO2_PUSH = "repository:$NAMESPACE_REPO2/$IMAGE:push"
+
+        const val SCOPE_REPO3_ALL = "repository:$NAMESPACE_REPO3/$IMAGE:*"
+        const val SCOPE_REPO3_PULL = "repository:$NAMESPACE_REPO3/$IMAGE:pull"
+        const val SCOPE_REPO3_PUSH = "repository:$NAMESPACE_REPO3/$IMAGE:push"
+
+        // Role attribute keys
+        private const val ATTR_REPO1 = "${ROLE_ATTRIBUTE_PREFIX}$NAMESPACE_REPO1"
+        private const val ATTR_REPO2 = "${ROLE_ATTRIBUTE_PREFIX}$NAMESPACE_REPO2"
+        private const val ATTR_REPO3 = "${ROLE_ATTRIBUTE_PREFIX}$NAMESPACE_REPO3"
+    }
+
+    @Nested
+    inner class RoleAttributeGrantsAccessTests {
+        @Test
+        internal fun role_with_push_pull_attribute_grants_push_access_without_group() {
+            // User has no groups but role with "registry:repository-1=pull,push"
+            setNamespaceScope(NAMESPACE_SCOPE_GROUP)
+            setRolesWithAttributes(
+                "repo1-role" to mapOf(ATTR_REPO1 to "pull,push")
+            )
+            setScope(SCOPE_REPO1_PUSH)
+            assertContainsOneAccessItemWithActions(ACTION_PUSH)
+        }
+
+        @Test
+        internal fun role_with_star_attribute_grants_all_actions_without_group() {
+            setNamespaceScope(NAMESPACE_SCOPE_GROUP)
+            setRolesWithAttributes(
+                "repo1-role" to mapOf(ATTR_REPO1 to "*")
+            )
+            setScope(SCOPE_REPO1_ALL)
+            assertContainsOneAccessItemWithActions(ACTION_PULL, ACTION_PUSH, ACTION_DELETE)
+        }
+
+        @Test
+        internal fun role_with_pull_only_attribute_grants_only_pull_access() {
+            setNamespaceScope(NAMESPACE_SCOPE_GROUP)
+            setRolesWithAttributes(
+                "repo2-role" to mapOf(ATTR_REPO2 to "pull")
+            )
+            setScope(SCOPE_REPO2_ALL)
+            assertContainsOneAccessItemWithActions(ACTION_PULL)
+        }
+
+        @Test
+        internal fun role_with_pull_only_attribute_denies_push() {
+            setNamespaceScope(NAMESPACE_SCOPE_GROUP)
+            setRolesWithAttributes(
+                "repo2-role" to mapOf(ATTR_REPO2 to "pull")
+            )
+            setScope(SCOPE_REPO2_PUSH)
+            assertEmptyAccessItems()
+        }
+
+        @Test
+        internal fun role_with_push_delete_attribute_without_pull() {
+            // Can have push,delete without pull
+            setNamespaceScope(NAMESPACE_SCOPE_GROUP)
+            setRolesWithAttributes(
+                "special-role" to mapOf(ATTR_REPO1 to "push,delete")
+            )
+            setScope(SCOPE_REPO1_PULL)
+            assertEmptyAccessItems()
+        }
+
+        @Test
+        internal fun role_with_push_delete_attribute_allows_push() {
+            setNamespaceScope(NAMESPACE_SCOPE_GROUP)
+            setRolesWithAttributes(
+                "special-role" to mapOf(ATTR_REPO1 to "push,delete")
+            )
+            setScope(SCOPE_REPO1_PUSH)
+            assertContainsOneAccessItemWithActions(ACTION_PUSH)
+        }
+
+        @Test
+        internal fun role_with_delete_only_attribute() {
+            setNamespaceScope(NAMESPACE_SCOPE_GROUP)
+            setRolesWithAttributes(
+                "delete-role" to mapOf(ATTR_REPO1 to "delete")
+            )
+            setScope(SCOPE_REPO1_DELETE)
+            assertContainsOneAccessItemWithActions(ACTION_DELETE)
+        }
+    }
+
+    @Nested
+    inner class MultipleNamespacePermissionsTests {
+        @Test
+        internal fun role_with_multiple_namespace_attributes() {
+            // One role with "registry:repository-1=pull,push,delete" and "registry:repository-2=pull"
+            setNamespaceScope(NAMESPACE_SCOPE_GROUP)
+            setRolesWithAttributes(
+                "multi-namespace-role" to mapOf(
+                    ATTR_REPO1 to "pull,push,delete",
+                    ATTR_REPO2 to "pull"
+                )
+            )
+
+            // Can push to repository-1
+            setScope(SCOPE_REPO1_PUSH)
+            assertContainsOneAccessItemWithActions(ACTION_PUSH)
+        }
+
+        @Test
+        internal fun role_with_multiple_namespace_attributes_repo2_pull_only() {
+            setNamespaceScope(NAMESPACE_SCOPE_GROUP)
+            setRolesWithAttributes(
+                "multi-namespace-role" to mapOf(
+                    ATTR_REPO1 to "pull,push,delete",
+                    ATTR_REPO2 to "pull"
+                )
+            )
+
+            // Can only pull from repository-2
+            setScope(SCOPE_REPO2_PUSH)
+            assertEmptyAccessItems()
+        }
+
+        @Test
+        internal fun role_with_multiple_namespace_attributes_repo2_can_pull() {
+            setNamespaceScope(NAMESPACE_SCOPE_GROUP)
+            setRolesWithAttributes(
+                "multi-namespace-role" to mapOf(
+                    ATTR_REPO1 to "pull,push,delete",
+                    ATTR_REPO2 to "pull"
+                )
+            )
+
+            setScope(SCOPE_REPO2_PULL)
+            assertContainsOneAccessItemWithActions(ACTION_PULL)
+        }
+    }
+
+    @Nested
+    inner class CombineWithGroupsTests {
+        @Test
+        internal fun group_access_with_global_editor_role() {
+            // User in group with global editor role (existing behavior)
+            setGroups(GROUP_REPO1)
+            setRoles(ROLE_EDITOR)
+            setNamespaceScope(NAMESPACE_SCOPE_GROUP)
+            setScope(SCOPE_REPO1_PUSH)
+            assertContainsOneAccessItemWithActions(ACTION_PUSH)
+        }
+
+        @Test
+        internal fun group_access_without_editor_role_only_pulls() {
+            // User in group without editor role -> pull only
+            setGroups(GROUP_REPO1)
+            setNamespaceScope(NAMESPACE_SCOPE_GROUP)
+            setScope(SCOPE_REPO1_ALL)
+            assertContainsOneAccessItemWithActions(ACTION_PULL)
+        }
+
+        @Test
+        internal fun group_access_with_role_attribute_adds_push() {
+            // User in group without global editor, but has role attribute granting push
+            setGroups(GROUP_REPO1)
+            setRolesWithAttributes(
+                "custom-role" to mapOf(ATTR_REPO1 to "push")
+            )
+            setNamespaceScope(NAMESPACE_SCOPE_GROUP)
+            setScope(SCOPE_REPO1_PUSH)
+            assertContainsOneAccessItemWithActions(ACTION_PUSH)
+        }
+
+        @Test
+        internal fun group_access_combines_pull_from_group_and_push_from_attribute() {
+            // User in group (gets pull) + role attribute (gets push)
+            // Should get both pull and push
+            setGroups(GROUP_REPO1)
+            setRolesWithAttributes(
+                "custom-role" to mapOf(ATTR_REPO1 to "push")
+            )
+            setNamespaceScope(NAMESPACE_SCOPE_GROUP)
+            setScope(SCOPE_REPO1_PULL_PUSH)
+            assertContainsOneAccessItemWithActions(ACTION_PULL, ACTION_PUSH)
+        }
+
+        @Test
+        internal fun mixed_group_and_role_attribute_access() {
+            // User in repository-1 group (pull only via group)
+            // User has role with "registry:repository-3=pull,push" (push/pull to repo3 via attribute)
+            setGroups(GROUP_REPO1)
+            setRolesWithAttributes(
+                "repo3-editor" to mapOf(ATTR_REPO3 to "pull,push")
+            )
+            setNamespaceScope(NAMESPACE_SCOPE_GROUP)
+
+            // Can only pull from repository-1 (group access, no push permission)
+            setScope(SCOPE_REPO1_PUSH)
+            assertEmptyAccessItems()
+        }
+
+        @Test
+        internal fun mixed_group_and_role_attribute_access_can_pull_from_group() {
+            setGroups(GROUP_REPO1)
+            setRolesWithAttributes(
+                "repo3-editor" to mapOf(ATTR_REPO3 to "pull,push")
+            )
+            setNamespaceScope(NAMESPACE_SCOPE_GROUP)
+
+            // Can pull from repository-1
+            setScope(SCOPE_REPO1_PULL)
+            assertContainsOneAccessItemWithActions(ACTION_PULL)
+        }
+
+        @Test
+        internal fun mixed_group_and_role_attribute_access_can_push_to_repo3() {
+            setGroups(GROUP_REPO1)
+            setRolesWithAttributes(
+                "repo3-editor" to mapOf(ATTR_REPO3 to "pull,push")
+            )
+            setNamespaceScope(NAMESPACE_SCOPE_GROUP)
+
+            // Can push to repository-3 (role attribute access)
+            setScope(SCOPE_REPO3_PUSH)
+            assertContainsOneAccessItemWithActions(ACTION_PUSH)
+        }
+    }
+
+    @Nested
+    inner class ComplexScenarioTests {
+        @Test
+        internal fun user_scenario_pull_from_groups_push_to_specific_via_attribute() {
+            // Scenario: User in 2 groups with just pull, but has role attribute for push on one specific namespace
+            // - User in registry-repository-1 and registry-repository-2 groups (pull only)
+            // - User has role "special" with "registry:repository-3=pull,push"
+            // Result: pull from repository-1/repository-2, push to repository-3
+
+            setGroups(GROUP_REPO1, GROUP_REPO2)
+            setRolesWithAttributes(
+                "special" to mapOf(ATTR_REPO3 to "pull,push")
+            )
+            setNamespaceScope(NAMESPACE_SCOPE_GROUP)
+
+            // Can pull from repository-1 (group)
+            setScope(SCOPE_REPO1_PULL)
+            assertContainsOneAccessItemWithActions(ACTION_PULL)
+        }
+
+        @Test
+        internal fun user_scenario_cannot_push_to_group_namespaces() {
+            setGroups(GROUP_REPO1, GROUP_REPO2)
+            setRolesWithAttributes(
+                "special" to mapOf(ATTR_REPO3 to "pull,push")
+            )
+            setNamespaceScope(NAMESPACE_SCOPE_GROUP)
+
+            // Cannot push to repository-1 (no push permission)
+            setScope(SCOPE_REPO1_PUSH)
+            assertEmptyAccessItems()
+        }
+
+        @Test
+        internal fun user_scenario_can_push_to_attribute_namespace() {
+            setGroups(GROUP_REPO1, GROUP_REPO2)
+            setRolesWithAttributes(
+                "special" to mapOf(ATTR_REPO3 to "pull,push")
+            )
+            setNamespaceScope(NAMESPACE_SCOPE_GROUP)
+
+            // Can push to repository-3 (role attribute)
+            setScope(SCOPE_REPO3_PUSH)
+            assertContainsOneAccessItemWithActions(ACTION_PUSH)
+        }
+
+        @Test
+        internal fun global_editor_combined_with_attribute_pull_only() {
+            // User has global editor role (push/delete for all group namespaces)
+            // But for a specific namespace via attribute, only pull is allowed
+            // Test that attribute restricts when accessing via attribute-only
+
+            setRolesWithAttributes(
+                ROLE_EDITOR to emptyMap(),
+                "restricted" to mapOf(ATTR_REPO3 to "pull")
+            )
+            setNamespaceScope(NAMESPACE_SCOPE_GROUP)
+
+            // Accessing repository-3 namespace (no group) via attribute only
+            // Should only get pull from attribute
+            setScope(SCOPE_REPO3_PUSH)
+            assertEmptyAccessItems()
+        }
+
+        @Test
+        internal fun global_editor_with_group_gets_full_access() {
+            // User has global editor role + group membership
+            setGroups(GROUP_REPO1)
+            setRoles(ROLE_EDITOR)
+            setNamespaceScope(NAMESPACE_SCOPE_GROUP)
+
+            setScope(SCOPE_REPO1_ALL)
+            assertContainsOneAccessItemWithActions(ACTION_PULL, ACTION_PUSH, ACTION_DELETE)
+        }
+    }
+
+    @Nested
+    inner class NoAccessTests {
+        @Test
+        internal fun no_group_no_attribute_denied() {
+            setNamespaceScope(NAMESPACE_SCOPE_GROUP)
+            // No groups, no role attributes
+            setScope(SCOPE_REPO3_PULL)
+            assertEmptyAccessItems()
+        }
+
+        @Test
+        internal fun wrong_namespace_attribute_denied() {
+            setNamespaceScope(NAMESPACE_SCOPE_GROUP)
+            setRolesWithAttributes(
+                "repo1-only" to mapOf(ATTR_REPO1 to "pull,push")
+            )
+            // Has repository-1 attribute but trying to access repository-3
+            setScope(SCOPE_REPO3_PULL)
+            assertEmptyAccessItems()
+        }
+    }
+
+    @Nested
+    inner class ActionCombinationTests {
+        @Test
+        internal fun attribute_with_spaces_in_value() {
+            setNamespaceScope(NAMESPACE_SCOPE_GROUP)
+            setRolesWithAttributes(
+                "spaced-role" to mapOf(ATTR_REPO1 to "pull, push, delete")
+            )
+            setScope(SCOPE_REPO1_ALL)
+            assertContainsOneAccessItemWithActions(ACTION_PULL, ACTION_PUSH, ACTION_DELETE)
+        }
+
+        @Test
+        internal fun attribute_with_uppercase_actions() {
+            setNamespaceScope(NAMESPACE_SCOPE_GROUP)
+            setRolesWithAttributes(
+                "upper-role" to mapOf(ATTR_REPO1 to "PULL,PUSH")
+            )
+            setScope(SCOPE_REPO1_PULL_PUSH)
+            assertContainsOneAccessItemWithActions(ACTION_PULL, ACTION_PUSH)
+        }
+
+        @Test
+        internal fun multiple_roles_combine_actions() {
+            // Two roles, each granting different actions
+            setNamespaceScope(NAMESPACE_SCOPE_GROUP)
+            setRolesWithAttributes(
+                "pull-role" to mapOf(ATTR_REPO1 to "pull"),
+                "push-role" to mapOf(ATTR_REPO1 to "push")
+            )
+            setScope(SCOPE_REPO1_PULL_PUSH)
+            assertContainsOneAccessItemWithActions(ACTION_PULL, ACTION_PUSH)
+        }
+    }
+}


### PR DESCRIPTION
Hi Alexander

Thanks for the keycloak-registry-mapper! I'm trying to use it together with the Docker registry but i stumbled upon a case.

I needed User X having access to Pull from repository A and pull/push from repository B while having
User Y having access to Pull from repository B and pull/push from repository A.

That doesn't align with the group approach and i searched for a solution on how to extend your plugin.
I'm not proficient in Kotlin so i vibe-coded (😳) an extension to your tooling that allows me to define specific client roles with fine-grained permissions.

I don't know if the code is mergable quality-wise but tests pass, it builds and i use it in a staging area where it "seems" to work just the way i wanted it.

Nevertheless, here is my PR. Totally understand of course if you don't want to review or merge it due to the circumstances of the "creational" process.

Also here is the Dockerfile of the Keycloak Instance i'm building for reference:
```
# Build keycloak-registry-mapper from source
FROM gradle:8-jdk21 AS mapper-builder
WORKDIR /build
RUN git clone https://github.com/pozylon/keycloak-registry-mapper.git .
RUN ./gradlew clean build -x test

FROM quay.io/keycloak/keycloak:26.5 AS builder

# Configure build-time options
ENV KC_DB=postgres
ENV KC_CACHE=ispn
ENV KC_CACHE_STACK=jdbc-ping
ENV KC_HEALTH_ENABLED=true
ENV KC_HTTP_ENABLED=true
ENV KC_FEATURES=docker,token-exchange

# Copy plugin from builder stage
COPY --from=mapper-builder /build/build/libs/*.jar /opt/keycloak/providers/

# Build optimized Keycloak
RUN /opt/keycloak/bin/kc.sh build

FROM quay.io/keycloak/keycloak:26.5

# Copy optimized build from builder stage
COPY --from=builder /opt/keycloak/ /opt/keycloak/

# Copy realm import files
COPY realm-*.json /opt/keycloak/data/import/

# Copy custom entrypoint for Docker secrets support
COPY entrypoint.sh /scripts/entrypoint.sh

USER root
RUN chmod +x /scripts/entrypoint.sh
USER keycloak

ENTRYPOINT ["/bin/bash", "/scripts/entrypoint.sh"]
CMD ["start", "--optimized", "--import-realm"]
```