### PR TITLE
Introduce fine grained groups

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,10 +9,10 @@ plugins {
     signing
 }
 
-val keycloakVersion = "26.5.0"
+val keycloakVersion = "26.5.4"
 
 group = "de.alexanderwolz"
-version = "1.9.2"
+version = "1.10.0"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/de/alexanderwolz/keycloak/registry/mapper/KeycloakGroupsAndRolesToDockerScopeMapper.kt
+++ b/src/main/kotlin/de/alexanderwolz/keycloak/registry/mapper/KeycloakGroupsAndRolesToDockerScopeMapper.kt
@@ -20,12 +20,10 @@ class KeycloakGroupsAndRolesToDockerScopeMapper : AbstractDockerScopeMapper(
         internal const val KEY_REGISTRY_GROUP_PREFIX = "REGISTRY_GROUP_PREFIX"
         internal const val DEFAULT_REGISTRY_GROUP_PREFIX = "registry-"
 
-        // anybody with access to namespace repo is considered 'user'
         private const val ROLE_USER = "user"
         internal const val ROLE_EDITOR = "editor"
         internal const val ROLE_ADMIN = "admin"
 
-        // can be 'user' or 'editor' or both separated by ','
         internal const val KEY_REGISTRY_CATALOG_AUDIENCE = "REGISTRY_CATALOG_AUDIENCE"
         internal const val AUDIENCE_USER = ROLE_USER
         internal const val AUDIENCE_EDITOR = ROLE_EDITOR
@@ -37,12 +35,36 @@ class KeycloakGroupsAndRolesToDockerScopeMapper : AbstractDockerScopeMapper(
         internal const val NAMESPACE_SCOPE_DOMAIN = "domain"
         internal const val NAMESPACE_SCOPE_SLD = "sld"
         internal val NAMESPACE_SCOPE_DEFAULT = setOf(NAMESPACE_SCOPE_GROUP)
+
+        // reserved namespace names that must not be used as Keycloak group names
+        internal val RESERVED_NAMESPACES = setOf(NAME_CATALOG, "default")
     }
 
     // will be overridden by tests
     internal var groupPrefix = getGroupPrefixFromEnv()
     internal var catalogAudience = getCatalogAudienceFromEnv()
     internal var namespaceScope = getNamespaceScopeFromEnv()
+
+    /**
+     * Represents a parsed Keycloak group path entry.
+     *
+     * Group path structure: /<groupPrefix><namespace>[/<repoPath>]/<role>
+     *
+     * Examples:
+     *   /registry-company1/user              -> namespace=company1, repoPath=null,        role=user
+     *   /registry-company1/editor            -> namespace=company1, repoPath=null,        role=editor
+     *   /registry-company1/myrepo/editor     -> namespace=company1, repoPath=myrepo,      role=editor
+     *   /registry-company1/team/myrepo/user  -> namespace=company1, repoPath=team/myrepo, role=user
+     *
+     * The last path segment must always be 'user' or 'editor' (the role leaf).
+     * Everything between namespace and role is treated as the repo path.
+     */
+    internal data class GroupAccess(
+        val namespace: String,
+        val repoPath: String?,          // null = namespace-level, otherwise full repo path e.g. "myrepo" or "team/myrepo"
+        val isEditor: Boolean,          // true = editor (pull+push+delete), false = user (pull only)
+        val hasExplicitRole: Boolean    // false = plain namespace group (e.g. registry-johnny), role comes from client role
+    )
 
     override fun appliesTo(responseToken: DockerResponseToken?): Boolean {
         return true
@@ -83,6 +105,7 @@ class KeycloakGroupsAndRolesToDockerScopeMapper : AbstractDockerScopeMapper(
         user: UserModel,
     ): DockerResponseToken {
 
+        // admin always wins
         if (clientRoleNames.contains(ROLE_ADMIN)) {
             return allowAll(responseToken, accessItem, user, "User has role '$ROLE_ADMIN'")
         }
@@ -132,34 +155,29 @@ class KeycloakGroupsAndRolesToDockerScopeMapper : AbstractDockerScopeMapper(
             responseToken, accessItem, user, "Role '$ROLE_ADMIN' needed to access default namespace repositories"
         )
 
+        // username scope: user always has full access to their own namespace
         if (namespaceScope.contains(NAMESPACE_SCOPE_USERNAME) && isUsernameRepository(namespace, user.username)) {
             val allowedActions = substituteRequestedActions(accessItem.actions)
             return allowWithActions(responseToken, accessItem, allowedActions, user, "Accessing user's own namespace")
         }
 
+        // domain/sld scopes: namespace matched via email, client role determines privileges
         if (namespaceScope.contains(NAMESPACE_SCOPE_DOMAIN) && isDomainRepository(namespace, user.email)) {
-            return handleNamespaceRepositoryAccess(responseToken, accessItem, clientRoleNames, user)
+            val isEditor = clientRoleNames.contains(ROLE_EDITOR)
+            return handleNamespaceRepositoryAccess(
+                responseToken, accessItem, isEditor, user, "Namespace match via domain"
+            )
         }
 
         if (namespaceScope.contains(NAMESPACE_SCOPE_SLD) && isSecondLevelDomainRepository(namespace, user.email)) {
-            return handleNamespaceRepositoryAccess(responseToken, accessItem, clientRoleNames, user)
+            val isEditor = clientRoleNames.contains(ROLE_EDITOR)
+            return handleNamespaceRepositoryAccess(
+                responseToken, accessItem, isEditor, user, "Namespace match via sld"
+            )
         }
 
         if (namespaceScope.contains(NAMESPACE_SCOPE_GROUP)) {
-            val namespacesFromGroups = getUserNamespacesFromGroups(user).also {
-                if (it.isEmpty()) {
-                    return deny(responseToken, accessItem, user, "User does not belong to any namespace - check groups")
-                }
-            }
-            if (namespacesFromGroups.contains(namespace)) {
-                return handleNamespaceRepositoryAccess(responseToken, accessItem, clientRoleNames, user)
-            }
-            return deny(
-                responseToken,
-                accessItem,
-                user,
-                "Missing namespace group '$groupPrefix$namespace' - check groups"
-            )
+            return handleGroupScopeAccess(responseToken, accessItem, clientRoleNames, namespace, user)
         }
 
         return deny(
@@ -168,51 +186,191 @@ class KeycloakGroupsAndRolesToDockerScopeMapper : AbstractDockerScopeMapper(
         )
     }
 
-    internal fun getUserNamespacesFromGroups(user: UserModel): Collection<String> {
-        val topLevelGroups = user.groupsStream.toList()
-        val allSubGroups = topLevelGroups.flatMap { it.subGroupsStream.toList() }
-        val allGroups = topLevelGroups + allSubGroups
-        return allGroups
-            .filter { it.name.lowercase().startsWith(groupPrefix) }
-            .map { it.name.lowercase().replace(groupPrefix, "") }
+    private fun handleGroupScopeAccess(
+        responseToken: DockerResponseToken,
+        accessItem: DockerScopeAccess,
+        clientRoleNames: Collection<String>,
+        namespace: String,
+        user: UserModel
+    ): DockerResponseToken {
+
+        val groupAccesses = getUserGroupAccesses(user)
+
+        if (groupAccesses.isEmpty()) {
+            return deny(responseToken, accessItem, user, "User does not belong to any namespace - check groups")
+        }
+
+        val requestedRepoPath = getRepoPathFromRepositoryName(accessItem.name)
+
+        // 1. repo-level override: check if user has explicit group for this exact repo
+        if (requestedRepoPath != null) {
+            val repoAccess = groupAccesses.find {
+                it.namespace == namespace && it.repoPath == requestedRepoPath
+            }
+            if (repoAccess != null) {
+                return handleNamespaceRepositoryAccess(
+                    responseToken, accessItem, repoAccess.isEditor, user,
+                    "Repo-level group override for '$namespace/$requestedRepoPath'"
+                )
+            }
+        }
+
+        // 2. namespace-level access: user has a namespace-level group (repoPath == null)
+        // if group has explicit role (user/editor leaf), use that; otherwise fall back to client role
+        val namespaceAccess = groupAccesses.find { it.namespace == namespace && it.repoPath == null }
+        if (namespaceAccess != null) {
+            val isEditor = if (namespaceAccess.hasExplicitRole) {
+                namespaceAccess.isEditor
+            } else {
+                clientRoleNames.contains(ROLE_EDITOR)
+            }
+            return handleNamespaceRepositoryAccess(
+                responseToken, accessItem, isEditor, user,
+                "Namespace-level group match for '$namespace'"
+            )
+        }
+
+        // 3. user has repo-level access in this namespace but not for this specific repo
+        val hasAnyAccessInNamespace = groupAccesses.any { it.namespace == namespace }
+        if (hasAnyAccessInNamespace) {
+            return deny(
+                responseToken, accessItem, user,
+                "No matching repo-level group for '$namespace/${requestedRepoPath ?: ""}' - check groups"
+            )
+        }
+
+        return deny(
+            responseToken, accessItem, user,
+            "Missing namespace group '$groupPrefix$namespace' - check groups"
+        )
+    }
+
+    /**
+     * Returns the repo path from a repository name, i.e. everything after the namespace segment.
+     * Returns null if there is no repo path beyond the namespace.
+     *
+     * Examples:
+     *   "namespace/myrepo"         -> "myrepo"
+     *   "namespace/team/myrepo"    -> "team/myrepo"
+     *   "image"                    -> null (no namespace)
+     */
+    internal fun getRepoPathFromRepositoryName(repositoryName: String): String? {
+        val parts = repositoryName.split("/")
+        if (parts.size < 2) return null
+        return parts.drop(1).joinToString("/")
+    }
+
+    /**
+     * Builds the full group path by traversing the parent chain upwards.
+     * Returns a slash-separated path without a leading slash,
+     * e.g. "registry-company1/myrepo/editor".
+     */
+    internal fun buildGroupPath(group: GroupModel): String {
+        val segments = mutableListOf(group.name)
+        var parent = group.parent
+        while (parent != null) {
+            segments.add(0, parent.name)
+            parent = parent.parent
+        }
+        return segments.joinToString("/")
+    }
+
+    /**
+     * Parses all Keycloak group memberships of a user into [GroupAccess] objects.
+     *
+     * Note: user.groupsStream returns ALL groups the user is directly a member of,
+     * including nested subgroups - Keycloak flattens this automatically.
+     * Groups that do not match the expected structure are silently ignored.
+     */
+    internal fun getUserGroupAccesses(user: UserModel): List<GroupAccess> {
+        return user.groupsStream.toList().mapNotNull { group ->
+            parseGroupPath(buildGroupPath(group))
+        }
+    }
+
+    /**
+     * Parses a Keycloak group path into a [GroupAccess] object.
+     *
+     * Path format: /<groupPrefix><namespace>[/<repoSegments...>]/<role>
+     *
+     * The last segment must be 'user' or 'editor'.
+     * Returns null if the path does not match the expected structure.
+     */
+    internal fun parseGroupPath(path: String): GroupAccess? {
+        // Keycloak paths always start with /, e.g. /registry-company1/myrepo/editor
+        val normalizedPath = path.lowercase().trimStart('/')
+        val segments = normalizedPath.split("/")
+
+        // first segment must start with groupPrefix
+        val firstSegment = segments[0]
+        if (!firstSegment.startsWith(groupPrefix)) return null
+
+        // extract namespace (everything after the prefix in the first segment)
+        val namespace = firstSegment.removePrefix(groupPrefix)
+        if (namespace.isEmpty()) return null
+
+        // plain namespace group e.g. registry-johnny (no role leaf)
+        // role is determined by client role, not group
+        if (segments.size == 1) {
+            return GroupAccess(namespace, repoPath = null, isEditor = false, hasExplicitRole = false)
+        }
+
+        // last segment must be the role leaf
+        val roleLeaf = segments.last()
+        val isEditor = when (roleLeaf) {
+            ROLE_EDITOR -> true
+            ROLE_USER -> false
+            else -> return null // not a valid role leaf, ignore this group
+        }
+
+        // everything between namespace segment and role leaf is the repo path
+        val repoSegments = segments.drop(1).dropLast(1)
+        val repoPath = if (repoSegments.isEmpty()) null else repoSegments.joinToString("/")
+
+        return GroupAccess(namespace, repoPath, isEditor, hasExplicitRole = true)
     }
 
     private fun handleNamespaceRepositoryAccess(
         responseToken: DockerResponseToken,
         accessItem: DockerScopeAccess,
-        clientRoleNames: Collection<String>,
-        user: UserModel
+        isEditor: Boolean,
+        user: UserModel,
+        context: String
     ): DockerResponseToken {
 
         val requestedActions = substituteRequestedActions(accessItem.actions)
-        val allowedActions = filterAllowedActions(requestedActions, clientRoleNames)
+        val allowedActions = filterAllowedActions(requestedActions, isEditor)
 
         if (allowedActions.isEmpty()) {
             return deny(
                 responseToken, accessItem, user,
-                "Missing privileges for actions [${accessItem.actions.joinToString()}] - check client roles"
+                "Missing privileges for actions [${accessItem.actions.joinToString()}] - $context"
             )
         }
 
         val reason = if (hasAllPrivileges(allowedActions, requestedActions)) {
-            "User has privilege on all actions"
+            "User has privilege on all actions ($context)"
         } else {
-            "User has privilege only on [${allowedActions.joinToString()}]"
+            "User has privilege only on [${allowedActions.joinToString()}] ($context)"
         }
         return allowWithActions(responseToken, accessItem, allowedActions, user, reason)
     }
 
+    /**
+     * Filters the requested actions based on whether the user is an editor or just a user.
+     * Editor: pull, push, delete, *
+     * User: pull only
+     */
     internal fun filterAllowedActions(
         requestedActions: Collection<String>,
-        clientRoleNames: Collection<String>,
+        isEditor: Boolean
     ): List<String> {
-        val isPrivileged = clientRoleNames.contains(ROLE_EDITOR) || clientRoleNames.contains(ROLE_ADMIN)
         return requestedActions.flatMap { action ->
             when (action) {
                 ACTION_PULL -> listOf(ACTION_PULL)
-                ACTION_PUSH -> if (isPrivileged) listOf(ACTION_PUSH) else emptyList()
-                ACTION_DELETE -> if (isPrivileged) listOf(ACTION_DELETE) else emptyList()
-                ACTION_ALL -> if (isPrivileged) listOf(ACTION_ALL) else listOf(ACTION_PULL)
+                ACTION_PUSH -> if (isEditor) listOf(ACTION_PUSH) else emptyList()
+                ACTION_DELETE -> if (isEditor) listOf(ACTION_DELETE) else emptyList()
+                ACTION_ALL -> if (isEditor) listOf(ACTION_ALL) else listOf(ACTION_PULL)
                 else -> emptyList()
             }
         }.distinct()

--- a/src/main/kotlin/de/alexanderwolz/keycloak/registry/mapper/KeycloakGroupsAndRolesToDockerScopeMapper.kt
+++ b/src/main/kotlin/de/alexanderwolz/keycloak/registry/mapper/KeycloakGroupsAndRolesToDockerScopeMapper.kt
@@ -20,7 +20,7 @@ class KeycloakGroupsAndRolesToDockerScopeMapper : AbstractDockerScopeMapper(
         internal const val KEY_REGISTRY_GROUP_PREFIX = "REGISTRY_GROUP_PREFIX"
         internal const val DEFAULT_REGISTRY_GROUP_PREFIX = "registry-"
 
-        private const val ROLE_USER = "user"
+        internal const val ROLE_USER = "user"
         internal const val ROLE_EDITOR = "editor"
         internal const val ROLE_ADMIN = "admin"
 

--- a/src/test/kotlin/de/alexanderwolz/keycloak/registry/mapper/KeycloakGroupsAndRolesToDockerScopeMapperTest.kt
+++ b/src/test/kotlin/de/alexanderwolz/keycloak/registry/mapper/KeycloakGroupsAndRolesToDockerScopeMapperTest.kt
@@ -9,204 +9,334 @@ import org.keycloak.models.GroupModel
 import org.keycloak.models.UserModel
 import org.mockito.Mockito
 import org.mockito.kotlin.given
-import java.util.stream.Stream
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 internal class KeycloakGroupsAndRolesToDockerScopeMapperTest {
 
     private val mapper = KeycloakGroupsAndRolesToDockerScopeMapper()
 
-    @Test
-    fun testGetUserNamespacesFromEmptyGroups() {
-        val user = Mockito.mock(UserModel::class.java)
-        given(user.groupsStream).willAnswer {
-            Stream.empty<GroupModel>()
+    // -------------------------------------------------------------------------
+    // Helper
+    // -------------------------------------------------------------------------
+
+    private fun mockGroup(name: String, parent: GroupModel? = null): GroupModel {
+        return Mockito.mock(GroupModel::class.java).also { group ->
+            given(group.name).willReturn(name)
+            given(group.parent).willReturn(parent)
         }
-        val actualGroupNames = mapper.getUserNamespacesFromGroups(user)
-        assertEquals(0, actualGroupNames.size)
+    }
+
+    private fun mockUser(vararg groups: GroupModel): UserModel {
+        return Mockito.mock(UserModel::class.java).also { user ->
+            given(user.groupsStream).willAnswer { groups.toList().stream() }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // buildGroupPath
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun testBuildGroupPathTopLevel() {
+        val group = mockGroup("registry-company1")
+        assertEquals("registry-company1", mapper.buildGroupPath(group))
     }
 
     @Test
-    fun testGetUserNamespacesFromGroupsAndSubgroups() {
-        val user = Mockito.mock(UserModel::class.java)
-        val groupWithPrefixSubgroup = "parentWithPrefixSubgroup"
-        val groupNames = setOf("${mapper.groupPrefix}company", "otherGroup", groupWithPrefixSubgroup)
-        val subgroupNames = setOf("${mapper.groupPrefix}subgroup", "otherSubgroup")
-        given(user.groupsStream).willAnswer {
-            groupNames.map { groupName ->
-                Mockito.mock(GroupModel::class.java).also { parentGroup ->
-                    given(parentGroup.name).willReturn(groupName)
-                    if (groupName == groupWithPrefixSubgroup) {
-                        given(parentGroup.subGroupsStream).willAnswer {
-                            subgroupNames.map { subgroupName ->
-                                Mockito.mock(GroupModel::class.java).also { childGroup ->
-                                    given(childGroup.name).willReturn(subgroupName)
-                                }
-                            }.stream()
-                        }
-                    }
-                }
-            }.stream()
-        }
-        val expectedGroupNames = setOf("company", "subgroup")
-        val actualGroupNames = mapper.getUserNamespacesFromGroups(user)
-        assertEquals(expectedGroupNames.sorted(), actualGroupNames.sorted())
+    fun testBuildGroupPathWithParent() {
+        val parent = mockGroup("registry-company1")
+        val child = mockGroup("editor", parent)
+        assertEquals("registry-company1/editor", mapper.buildGroupPath(child))
     }
 
     @Test
-    fun testGetUserNamespacesFromSubgroupsOnly() {
-        val user = Mockito.mock(UserModel::class.java)
-        val groupWithPrefixSubgroup = "parentWithPrefixSubgroup"
-        val groupNames = setOf("otherGroup1", "otherGroup2", groupWithPrefixSubgroup)
-        val subgroupNames = setOf("${mapper.groupPrefix}subgroup1", "${mapper.groupPrefix}subgroup2", "otherSubgroup")
-        given(user.groupsStream).willAnswer {
-            groupNames.map { groupName ->
-                Mockito.mock(GroupModel::class.java).also { parentGroup ->
-                    given(parentGroup.name).willReturn(groupName)
-                    if (groupName == groupWithPrefixSubgroup) {
-                        given(parentGroup.subGroupsStream).willAnswer {
-                            subgroupNames.map { subgroupName ->
-                                Mockito.mock(GroupModel::class.java).also { childGroup ->
-                                    given(childGroup.name).willReturn(subgroupName)
-                                }
-                            }.stream()
-                        }
-                    }
-                }
-            }.stream()
-        }
-        val expectedGroupNames = setOf("subgroup1", "subgroup2")
-        val actualGroupNames = mapper.getUserNamespacesFromGroups(user)
-        assertEquals(expectedGroupNames.sorted(), actualGroupNames.sorted())
+    fun testBuildGroupPathWithGrandParent() {
+        val grandParent = mockGroup("registry-company1")
+        val parent = mockGroup("myrepo", grandParent)
+        val child = mockGroup("editor", parent)
+        assertEquals("registry-company1/myrepo/editor", mapper.buildGroupPath(child))
     }
 
     @Test
-    fun testGetUserNamespacesFromCustomGroupPrefix() {
-        val customPrefix = "_MY-GROUP-PREFIX_".lowercase()
+    fun testBuildGroupPathDeepNesting() {
+        val level1 = mockGroup("registry-company1")
+        val level2 = mockGroup("team", level1)
+        val level3 = mockGroup("myrepo", level2)
+        val level4 = mockGroup("user", level3)
+        assertEquals("registry-company1/team/myrepo/user", mapper.buildGroupPath(level4))
+    }
+
+    // -------------------------------------------------------------------------
+    // parseGroupPath
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun testParseGroupPathPlainNamespace() {
+        val result = mapper.parseGroupPath("registry-company1")
+        assertNotNull(result)
+        assertEquals("company1", result.namespace)
+        assertNull(result.repoPath)
+        assertEquals(false, result.isEditor)
+        assertEquals(false, result.hasExplicitRole)
+    }
+
+    @Test
+    fun testParseGroupPathNamespaceUserLeaf() {
+        val result = mapper.parseGroupPath("registry-company1/user")
+        assertNotNull(result)
+        assertEquals("company1", result.namespace)
+        assertNull(result.repoPath)
+        assertEquals(false, result.isEditor)
+        assertEquals(true, result.hasExplicitRole)
+    }
+
+    @Test
+    fun testParseGroupPathNamespaceEditorLeaf() {
+        val result = mapper.parseGroupPath("registry-company1/editor")
+        assertNotNull(result)
+        assertEquals("company1", result.namespace)
+        assertNull(result.repoPath)
+        assertEquals(true, result.isEditor)
+        assertEquals(true, result.hasExplicitRole)
+    }
+
+    @Test
+    fun testParseGroupPathRepoLevelUser() {
+        val result = mapper.parseGroupPath("registry-company1/myrepo/user")
+        assertNotNull(result)
+        assertEquals("company1", result.namespace)
+        assertEquals("myrepo", result.repoPath)
+        assertEquals(false, result.isEditor)
+        assertEquals(true, result.hasExplicitRole)
+    }
+
+    @Test
+    fun testParseGroupPathRepoLevelEditor() {
+        val result = mapper.parseGroupPath("registry-company1/myrepo/editor")
+        assertNotNull(result)
+        assertEquals("company1", result.namespace)
+        assertEquals("myrepo", result.repoPath)
+        assertEquals(true, result.isEditor)
+        assertEquals(true, result.hasExplicitRole)
+    }
+
+    @Test
+    fun testParseGroupPathDeepRepoPath() {
+        val result = mapper.parseGroupPath("registry-company1/team/myrepo/editor")
+        assertNotNull(result)
+        assertEquals("company1", result.namespace)
+        assertEquals("team/myrepo", result.repoPath)
+        assertEquals(true, result.isEditor)
+        assertEquals(true, result.hasExplicitRole)
+    }
+
+    @Test
+    fun testParseGroupPathWithLeadingSlash() {
+        val result = mapper.parseGroupPath("/registry-company1/myrepo/editor")
+        assertNotNull(result)
+        assertEquals("company1", result.namespace)
+        assertEquals("myrepo", result.repoPath)
+        assertEquals(true, result.isEditor)
+    }
+
+    @Test
+    fun testParseGroupPathIgnoresNonPrefixedGroup() {
+        assertNull(mapper.parseGroupPath("othergroup/editor"))
+    }
+
+    @Test
+    fun testParseGroupPathIgnoresInvalidRoleLeaf() {
+        assertNull(mapper.parseGroupPath("registry-company1/admin"))
+    }
+
+    @Test
+    fun testParseGroupPathIgnoresEmptyNamespace() {
+        assertNull(mapper.parseGroupPath("registry-"))
+    }
+
+    @Test
+    fun testParseGroupPathCustomPrefix() {
+        mapper.groupPrefix = "myprefix-"
+        val result = mapper.parseGroupPath("myprefix-company1/editor")
+        assertNotNull(result)
+        assertEquals("company1", result.namespace)
+        mapper.groupPrefix = KeycloakGroupsAndRolesToDockerScopeMapper.DEFAULT_REGISTRY_GROUP_PREFIX
+    }
+
+    // -------------------------------------------------------------------------
+    // getUserGroupAccesses
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun testGetUserGroupAccessesEmpty() {
+        val user = mockUser()
+        assertEquals(0, mapper.getUserGroupAccesses(user).size)
+    }
+
+    @Test
+    fun testGetUserGroupAccessesPlainNamespaceGroup() {
+        val group = mockGroup("registry-company1")
+        val user = mockUser(group)
+        val accesses = mapper.getUserGroupAccesses(user)
+        assertEquals(1, accesses.size)
+        assertEquals("company1", accesses.first().namespace)
+        assertNull(accesses.first().repoPath)
+        assertEquals(false, accesses.first().hasExplicitRole)
+    }
+
+    @Test
+    fun testGetUserGroupAccessesWithRoleLeaf() {
+        val parent = mockGroup("registry-company1")
+        val child = mockGroup("editor", parent)
+        val user = mockUser(parent, child)
+        val accesses = mapper.getUserGroupAccesses(user)
+        assertEquals(2, accesses.size)
+        val namespaceAccess = accesses.find { !it.hasExplicitRole }
+        assertNotNull(namespaceAccess)
+        assertEquals("company1", namespaceAccess.namespace)
+        val roleAccess = accesses.find { it.hasExplicitRole && it.repoPath == null }
+        assertNotNull(roleAccess)
+        assertEquals(true, roleAccess.isEditor)
+    }
+
+    @Test
+    fun testGetUserGroupAccessesWithRepoOverride() {
+        val parent = mockGroup("registry-company1")
+        val repoGroup = mockGroup("myrepo", parent)
+        val roleGroup = mockGroup("editor", repoGroup)
+        val user = mockUser(parent, roleGroup)
+        val accesses = mapper.getUserGroupAccesses(user)
+        assertEquals(2, accesses.size)
+        val repoAccess = accesses.find { it.repoPath == "myrepo" }
+        assertNotNull(repoAccess)
+        assertEquals("company1", repoAccess.namespace)
+        assertEquals(true, repoAccess.isEditor)
+        assertEquals(true, repoAccess.hasExplicitRole)
+    }
+
+    @Test
+    fun testGetUserGroupAccessesIgnoresNonPrefixedGroups() {
+        val otherGroup = mockGroup("someothergroup")
+        val user = mockUser(otherGroup)
+        assertEquals(0, mapper.getUserGroupAccesses(user).size)
+    }
+
+    @Test
+    fun testGetUserGroupAccessesWithCustomPrefix() {
+        val customPrefix = "_my-group-prefix_"
         mapper.groupPrefix = customPrefix
-        assertEquals(mapper.groupPrefix, customPrefix)
-
-        val user = Mockito.mock(UserModel::class.java)
-        val groupNames = setOf("${customPrefix}company", "otherGroup")
-
-        given(user.groupsStream).willAnswer {
-            groupNames.map { groupName ->
-                Mockito.mock(GroupModel::class.java).also { parentGroup ->
-                    given(parentGroup.name).willReturn(groupName)
-                }
-            }.stream()
-        }
-        val expectedGroupNames = setOf("company")
-        val actualGroupNames = mapper.getUserNamespacesFromGroups(user)
-        assertEquals(expectedGroupNames.sorted(), actualGroupNames.sorted())
+        val group = mockGroup("${customPrefix}company")
+        val user = mockUser(group)
+        val accesses = mapper.getUserGroupAccesses(user)
+        assertEquals(1, accesses.size)
+        assertEquals("company", accesses.first().namespace)
+        mapper.groupPrefix = KeycloakGroupsAndRolesToDockerScopeMapper.DEFAULT_REGISTRY_GROUP_PREFIX
     }
+
+    @Test
+    fun testGetUserGroupAccessesNamespaceOnlyReturnsNoRepoPath() {
+        val group = mockGroup("${mapper.groupPrefix}company")
+        val user = mockUser(group)
+        val accesses = mapper.getUserGroupAccesses(user)
+        assertEquals(1, accesses.size)
+        assertNull(accesses.first().repoPath)
+    }
+
+    @Test
+    fun testGetUserGroupAccessesRepoGroupDoesNotContributeNamespace() {
+        // user is only member of the leaf role group, not of the namespace group itself
+        val namespaceGroup = mockGroup("${mapper.groupPrefix}company")
+        val repoGroup = mockGroup("myrepo", namespaceGroup)
+        val roleGroup = mockGroup("editor", repoGroup)
+        val user = mockUser(roleGroup)
+        val accesses = mapper.getUserGroupAccesses(user)
+        assertEquals(1, accesses.size)
+        assertEquals("myrepo", accesses.first().repoPath)
+        assertNull(accesses.find { it.repoPath == null })
+    }
+
+    // -------------------------------------------------------------------------
+    // getRepoPathFromRepositoryName
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun testGetRepoPathSimple() {
+        assertEquals("myrepo", mapper.getRepoPathFromRepositoryName("namespace/myrepo"))
+    }
+
+    @Test
+    fun testGetRepoPathNested() {
+        assertEquals("team/myrepo", mapper.getRepoPathFromRepositoryName("namespace/team/myrepo"))
+    }
+
+    @Test
+    fun testGetRepoPathNoNamespace() {
+        assertNull(mapper.getRepoPathFromRepositoryName("image"))
+    }
+
+    // -------------------------------------------------------------------------
+    // filterAllowedActions
+    // -------------------------------------------------------------------------
 
     @Test
     fun testFilterAllowedActionsAllForUser() {
-        val requestedActions = setOf(ACTION_ALL)
-        val clientRoleNames = emptySet<String>()
-        val allowedActions = mapper.filterAllowedActions(requestedActions, clientRoleNames)
-        val expectedActions = setOf(ACTION_PULL)
-        assertEquals(expectedActions.sorted(), allowedActions.sorted())
+        assertEquals(listOf(ACTION_PULL), mapper.filterAllowedActions(setOf(ACTION_ALL), isEditor = false).sorted())
     }
 
     @Test
     fun testFilterAllowedActionsPullForUser() {
-        val requestedActions = setOf(ACTION_PULL)
-        val clientRoleNames = emptySet<String>()
-        val allowedActions = mapper.filterAllowedActions(requestedActions, clientRoleNames)
-        val expectedActions = setOf(ACTION_PULL)
-        assertEquals(expectedActions.sorted(), allowedActions.sorted())
+        assertEquals(listOf(ACTION_PULL), mapper.filterAllowedActions(setOf(ACTION_PULL), isEditor = false).sorted())
     }
 
     @Test
     fun testFilterAllowedActionsPushForUser() {
-        val requestedActions = setOf(ACTION_PUSH)
-        val clientRoleNames = emptySet<String>()
-        val allowedActions = mapper.filterAllowedActions(requestedActions, clientRoleNames)
-        val expectedActions = emptySet<String>()
-        assertEquals(expectedActions.sorted(), allowedActions.sorted())
+        assertEquals(emptyList<String>(), mapper.filterAllowedActions(setOf(ACTION_PUSH), isEditor = false).sorted())
     }
 
     @Test
     fun testFilterAllowedActionsDeleteForUser() {
-        val requestedActions = setOf(ACTION_DELETE)
-        val clientRoleNames = emptySet<String>()
-        val allowedActions = mapper.filterAllowedActions(requestedActions, clientRoleNames)
-        val expectedActions = emptySet<String>()
-        assertEquals(expectedActions.sorted(), allowedActions.sorted())
+        assertEquals(emptyList<String>(), mapper.filterAllowedActions(setOf(ACTION_DELETE), isEditor = false).sorted())
     }
 
     @Test
     fun testFilterAllowedActionsPullPushForUser() {
-        val requestedActions = setOf(ACTION_PULL, ACTION_PUSH)
-        val clientRoleNames = emptySet<String>()
-        val allowedActions = mapper.filterAllowedActions(requestedActions, clientRoleNames)
-        val expectedActions = setOf(ACTION_PULL)
-        assertEquals(expectedActions.sorted(), allowedActions.sorted())
+        assertEquals(listOf(ACTION_PULL), mapper.filterAllowedActions(setOf(ACTION_PULL, ACTION_PUSH), isEditor = false).sorted())
     }
 
     @Test
     fun testFilterAllowedActionsPullPushDeleteForUser() {
-        val requestedActions = setOf(ACTION_PULL, ACTION_PUSH, ACTION_DELETE)
-        val clientRoleNames = emptySet<String>()
-        val allowedActions = mapper.filterAllowedActions(requestedActions, clientRoleNames)
-        val expectedActions = setOf(ACTION_PULL)
-        assertEquals(expectedActions.sorted(), allowedActions.sorted())
+        assertEquals(listOf(ACTION_PULL), mapper.filterAllowedActions(setOf(ACTION_PULL, ACTION_PUSH, ACTION_DELETE), isEditor = false).sorted())
     }
 
     @Test
     fun testFilterAllowedActionsAllForEditor() {
-        val requestedActions = setOf(ACTION_ALL)
-        val clientRoleNames = setOf(KeycloakGroupsAndRolesToDockerScopeMapper.ROLE_EDITOR)
-        val allowedActions = mapper.filterAllowedActions(requestedActions, clientRoleNames)
-        val expectedActions = setOf(ACTION_ALL)
-        assertEquals(expectedActions.sorted(), allowedActions.sorted())
+        assertEquals(listOf(ACTION_ALL), mapper.filterAllowedActions(setOf(ACTION_ALL), isEditor = true).sorted())
     }
 
     @Test
     fun testFilterAllowedActionsPullForEditor() {
-        val requestedActions = setOf(ACTION_PULL)
-        val clientRoleNames = setOf(KeycloakGroupsAndRolesToDockerScopeMapper.ROLE_EDITOR)
-        val allowedActions = mapper.filterAllowedActions(requestedActions, clientRoleNames)
-        val expectedActions = setOf(ACTION_PULL)
-        assertEquals(expectedActions.sorted(), allowedActions.sorted())
+        assertEquals(listOf(ACTION_PULL), mapper.filterAllowedActions(setOf(ACTION_PULL), isEditor = true).sorted())
     }
 
     @Test
     fun testFilterAllowedActionsPushForEditor() {
-        val requestedActions = setOf(ACTION_PUSH)
-        val clientRoleNames = setOf(KeycloakGroupsAndRolesToDockerScopeMapper.ROLE_EDITOR)
-        val allowedActions = mapper.filterAllowedActions(requestedActions, clientRoleNames)
-        val expectedActions = setOf(ACTION_PUSH)
-        assertEquals(expectedActions.sorted(), allowedActions.sorted())
+        assertEquals(listOf(ACTION_PUSH), mapper.filterAllowedActions(setOf(ACTION_PUSH), isEditor = true).sorted())
     }
 
     @Test
     fun testFilterAllowedActionsDeleteForEditor() {
-        val requestedActions = setOf(ACTION_DELETE)
-        val clientRoleNames = setOf(KeycloakGroupsAndRolesToDockerScopeMapper.ROLE_EDITOR)
-        val allowedActions = mapper.filterAllowedActions(requestedActions, clientRoleNames)
-        val expectedActions = setOf(ACTION_DELETE)
-        assertEquals(expectedActions.sorted(), allowedActions.sorted())
+        assertEquals(listOf(ACTION_DELETE), mapper.filterAllowedActions(setOf(ACTION_DELETE), isEditor = true).sorted())
     }
 
     @Test
     fun testFilterAllowedActionsPullPushForEditor() {
-        val requestedActions = setOf(ACTION_PULL, ACTION_PUSH)
-        val clientRoleNames = setOf(KeycloakGroupsAndRolesToDockerScopeMapper.ROLE_EDITOR)
-        val allowedActions = mapper.filterAllowedActions(requestedActions, clientRoleNames)
-        val expectedActions = setOf(ACTION_PULL, ACTION_PUSH)
-        assertEquals(expectedActions.sorted(), allowedActions.sorted())
+        assertEquals(listOf(ACTION_PULL, ACTION_PUSH).sorted(), mapper.filterAllowedActions(setOf(ACTION_PULL, ACTION_PUSH), isEditor = true).sorted())
     }
 
     @Test
     fun testFilterAllowedActionsPullPushDeleteForEditor() {
-        val requestedActions = setOf(ACTION_PULL, ACTION_PUSH, ACTION_DELETE)
-        val clientRoleNames = setOf(KeycloakGroupsAndRolesToDockerScopeMapper.ROLE_EDITOR)
-        val allowedActions = mapper.filterAllowedActions(requestedActions, clientRoleNames)
-        val expectedActions = setOf(ACTION_PULL, ACTION_PUSH, ACTION_DELETE)
-        assertEquals(expectedActions.sorted(), allowedActions.sorted())
+        assertEquals(listOf(ACTION_PULL, ACTION_PUSH, ACTION_DELETE).sorted(), mapper.filterAllowedActions(setOf(ACTION_PULL, ACTION_PUSH, ACTION_DELETE), isEditor = true).sorted())
     }
-
 }

--- a/src/test/kotlin/de/alexanderwolz/keycloak/registry/mapper/testsuite/AbstractScopeMapperTestSuite.kt
+++ b/src/test/kotlin/de/alexanderwolz/keycloak/registry/mapper/testsuite/AbstractScopeMapperTestSuite.kt
@@ -21,10 +21,10 @@ abstract class AbstractScopeMapperTestSuite {
         private const val CLIENT_ID = "registry"
         private const val USER_NAME = "Johnny"
         private const val USER_EMAIL = "john.doe@johnny.com"
-        private const val IMAGE = "image"
 
-        private const val NAMESPACE = "johnny"
-        private const val NAMESPACE_DOMAIN = "johnny.com"
+        const val IMAGE = "image"
+        const val NAMESPACE = "johnny"
+        const val NAMESPACE_DOMAIN = "johnny.com"
 
         // scopes can either be registry, repository or repository(plugin)
         const val SCOPE_REGISTRY_CATALOG_ALL = "registry:catalog:*"
@@ -66,6 +66,12 @@ abstract class AbstractScopeMapperTestSuite {
         const val SCOPE_REPO_PLUGIN_NAMESPACE_DOMAIN_DELETE = "repository(plugin):$NAMESPACE_DOMAIN/$IMAGE:delete"
         const val SCOPE_REPO_PLUGIN_NAMESPACE_DOMAIN_PULL_PUSH = "repository(plugin):$NAMESPACE_DOMAIN/$IMAGE:pull,push"
 
+        const val SCOPE_DEEP_REPO_ALL = "repository:$NAMESPACE/team/$IMAGE:*"
+        const val SCOPE_DEEP_REPO_PULL = "repository:$NAMESPACE/team/$IMAGE:pull"
+        const val SCOPE_DEEP_REPO_PUSH = "repository:$NAMESPACE/team/$IMAGE:push"
+        const val SCOPE_DEEP_REPO_DELETE = "repository:$NAMESPACE/team/$IMAGE:delete"
+        const val SCOPE_DEEP_REPO_PULL_PUSH = "repository:$NAMESPACE/team/$IMAGE:pull,push"
+
         private const val GROUP_PREFIX = KeycloakGroupsAndRolesToDockerScopeMapper.DEFAULT_REGISTRY_GROUP_PREFIX
         const val GROUP_NAMESPACE = "${GROUP_PREFIX}$NAMESPACE"
         const val GROUP_NAMESPACE_OTHER = "${GROUP_PREFIX}otherNamespace"
@@ -73,7 +79,6 @@ abstract class AbstractScopeMapperTestSuite {
 
     private val logger = Logger.getLogger(javaClass)
 
-    //transformDockerResponseToken - uses responseToken, userSession and clientSession
     private lateinit var mapper: KeycloakGroupsAndRolesToDockerScopeMapper
 
     private lateinit var responseToken: DockerResponseToken
@@ -100,7 +105,6 @@ abstract class AbstractScopeMapperTestSuite {
 
         mapper = KeycloakGroupsAndRolesToDockerScopeMapper()
 
-        //unused objects but necessary because of signature
         responseToken = DockerResponseToken()
         mappingModel = ProtocolMapperModel()
         session = Mockito.mock(KeycloakSession::class.java)
@@ -129,6 +133,27 @@ abstract class AbstractScopeMapperTestSuite {
         val groups = createGroupsByNames(*groupNames)
         given(userModel.groupsStream).willAnswer { groups.stream() }
         assertEquals(groups, userModel.groupsStream.toList())
+    }
+
+    protected fun setNestedGroups(vararg groupPaths: String) {
+        val leafGroups = groupPaths.map { path -> buildNestedGroupChain(path) }
+        given(userModel.groupsStream).willAnswer { leafGroups.stream() }
+    }
+
+    private fun buildNestedGroupChain(path: String): GroupModel {
+        val segments = path.trim('/').split("/")
+        var parent: GroupModel? = null
+        var leaf: GroupModel = Mockito.mock(GroupModel::class.java)
+        segments.forEachIndexed { index, name ->
+            val group = Mockito.mock(GroupModel::class.java)
+            BDDMockito.given(group.name).willReturn(name)
+            BDDMockito.given(group.parent).willReturn(parent)
+            parent = group
+            if (index == segments.lastIndex) {
+                leaf = group
+            }
+        }
+        return leaf
     }
 
     protected open fun setRoles(vararg roleNames: String) {
@@ -162,11 +187,6 @@ abstract class AbstractScopeMapperTestSuite {
         assertEquals(expectedActions.sorted(), actualToken.accessItems.first().actions.sorted())
     }
 
-
-    /**
-     *  convenience methods
-     */
-
     private fun transformDockerResponseToken(): DockerResponseToken {
         return mapper.transformDockerResponseToken(
             responseToken, mappingModel, session, userSession, clientSession
@@ -193,5 +213,4 @@ abstract class AbstractScopeMapperTestSuite {
             role
         }
     }
-
 }

--- a/src/test/kotlin/de/alexanderwolz/keycloak/registry/mapper/testsuite/GroupOverrideTestSuite.kt
+++ b/src/test/kotlin/de/alexanderwolz/keycloak/registry/mapper/testsuite/GroupOverrideTestSuite.kt
@@ -1,0 +1,355 @@
+package de.alexanderwolz.keycloak.registry.mapper.testsuite
+
+import de.alexanderwolz.keycloak.registry.mapper.AbstractDockerScopeMapper.Companion.ACTION_DELETE
+import de.alexanderwolz.keycloak.registry.mapper.AbstractDockerScopeMapper.Companion.ACTION_PULL
+import de.alexanderwolz.keycloak.registry.mapper.AbstractDockerScopeMapper.Companion.ACTION_PUSH
+import de.alexanderwolz.keycloak.registry.mapper.KeycloakGroupsAndRolesToDockerScopeMapper.Companion.DEFAULT_REGISTRY_GROUP_PREFIX
+import de.alexanderwolz.keycloak.registry.mapper.KeycloakGroupsAndRolesToDockerScopeMapper.Companion.ROLE_EDITOR
+import de.alexanderwolz.keycloak.registry.mapper.KeycloakGroupsAndRolesToDockerScopeMapper.Companion.ROLE_USER
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class GroupOverrideTestSuite : AbstractScopeMapperTestSuite() {
+
+    private val prefix = DEFAULT_REGISTRY_GROUP_PREFIX
+
+    private val namespaceGroup = "$prefix$NAMESPACE"
+    private val repoEditorGroup = "$prefix$NAMESPACE/$IMAGE/editor"
+    private val repoUserGroup = "$prefix$NAMESPACE/$IMAGE/user"
+    private val otherRepoEditorGroup = "$prefix$NAMESPACE/otherrepo/editor"
+    private val deepRepoEditorGroup = "$prefix$NAMESPACE/team/$IMAGE/editor"
+    private val deepRepoUserGroup = "$prefix$NAMESPACE/team/$IMAGE/user"
+
+    // -------------------------------------------------------------------------
+    // Repo-level editor override (client role: user) -> pull+push+delete
+    // -------------------------------------------------------------------------
+
+    @Nested
+    inner class RepoEditorOverrideWithClientRoleUserTests {
+
+        @Test
+        internal fun repo_editor_override_client_user_on_scope_all() {
+            setNestedGroups(repoEditorGroup)
+            setRoles(ROLE_USER)
+            setScope(SCOPE_REPO_NAMESPACE_ALL)
+            assertContainsOneAccessItemWithActions(ACTION_PULL, ACTION_PUSH, ACTION_DELETE)
+        }
+
+        @Test
+        internal fun repo_editor_override_client_user_on_scope_pull() {
+            setNestedGroups(repoEditorGroup)
+            setRoles(ROLE_USER)
+            setScope(SCOPE_REPO_NAMESPACE_PULL)
+            assertContainsOneAccessItemWithActions(ACTION_PULL)
+        }
+
+        @Test
+        internal fun repo_editor_override_client_user_on_scope_push() {
+            setNestedGroups(repoEditorGroup)
+            setRoles(ROLE_USER)
+            setScope(SCOPE_REPO_NAMESPACE_PUSH)
+            assertContainsOneAccessItemWithActions(ACTION_PUSH)
+        }
+
+        @Test
+        internal fun repo_editor_override_client_user_on_scope_delete() {
+            setNestedGroups(repoEditorGroup)
+            setRoles(ROLE_USER)
+            setScope(SCOPE_REPO_NAMESPACE_DELETE)
+            assertContainsOneAccessItemWithActions(ACTION_DELETE)
+        }
+
+        @Test
+        internal fun repo_editor_override_client_user_on_scope_pull_push() {
+            setNestedGroups(repoEditorGroup)
+            setRoles(ROLE_USER)
+            setScope(SCOPE_REPO_NAMESPACE_PULL_PUSH)
+            assertContainsOneAccessItemWithActions(ACTION_PULL, ACTION_PUSH)
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Repo-level user override (client role: editor) -> pull only
+    // -------------------------------------------------------------------------
+
+    @Nested
+    inner class RepoUserOverrideWithClientRoleEditorTests {
+
+        @Test
+        internal fun repo_user_override_client_editor_on_scope_all() {
+            setNestedGroups(repoUserGroup)
+            setRoles(ROLE_EDITOR)
+            setScope(SCOPE_REPO_NAMESPACE_ALL)
+            assertContainsOneAccessItemWithActions(ACTION_PULL)
+        }
+
+        @Test
+        internal fun repo_user_override_client_editor_on_scope_pull() {
+            setNestedGroups(repoUserGroup)
+            setRoles(ROLE_EDITOR)
+            setScope(SCOPE_REPO_NAMESPACE_PULL)
+            assertContainsOneAccessItemWithActions(ACTION_PULL)
+        }
+
+        @Test
+        internal fun repo_user_override_client_editor_on_scope_push() {
+            setNestedGroups(repoUserGroup)
+            setRoles(ROLE_EDITOR)
+            setScope(SCOPE_REPO_NAMESPACE_PUSH)
+            assertEmptyAccessItems()
+        }
+
+        @Test
+        internal fun repo_user_override_client_editor_on_scope_delete() {
+            setNestedGroups(repoUserGroup)
+            setRoles(ROLE_EDITOR)
+            setScope(SCOPE_REPO_NAMESPACE_DELETE)
+            assertEmptyAccessItems()
+        }
+
+        @Test
+        internal fun repo_user_override_client_editor_on_scope_pull_push() {
+            setNestedGroups(repoUserGroup)
+            setRoles(ROLE_EDITOR)
+            setScope(SCOPE_REPO_NAMESPACE_PULL_PUSH)
+            assertContainsOneAccessItemWithActions(ACTION_PULL)
+        }
+    }
+
+    @Nested
+    inner class NamespaceGroupPlusRepoOverrideTests {
+
+        // namespace group (client role: user) + repo editor override
+        // overridden repo: editor wins -> push allowed
+        // other repos: client role user -> pull only
+
+        @Test
+        internal fun namespace_plus_repo_editor_override_on_overridden_repo_all() {
+            setNestedGroups(namespaceGroup, repoEditorGroup)
+            setRoles(ROLE_USER)
+            setScope(SCOPE_REPO_NAMESPACE_ALL)
+            assertContainsOneAccessItemWithActions(ACTION_PULL, ACTION_PUSH, ACTION_DELETE)
+        }
+
+        @Test
+        internal fun namespace_plus_repo_editor_override_on_overridden_repo_push() {
+            setNestedGroups(namespaceGroup, repoEditorGroup)
+            setRoles(ROLE_USER)
+            setScope(SCOPE_REPO_NAMESPACE_PUSH)
+            assertContainsOneAccessItemWithActions(ACTION_PUSH)
+        }
+
+        @Test
+        internal fun namespace_plus_repo_editor_override_on_other_repo_pull_allowed() {
+            setNestedGroups(namespaceGroup, repoEditorGroup)
+            setRoles(ROLE_USER)
+            setScope("repository:$NAMESPACE/otherrepo:pull")
+            assertContainsOneAccessItemWithActions(ACTION_PULL)
+        }
+
+        @Test
+        internal fun namespace_plus_repo_editor_override_on_other_repo_push_denied() {
+            setNestedGroups(namespaceGroup, repoEditorGroup)
+            setRoles(ROLE_USER)
+            setScope("repository:$NAMESPACE/otherrepo:push")
+            assertEmptyAccessItems()
+        }
+
+        // namespace group (client role: editor) + repo user override
+        // overridden repo: user wins -> push denied
+        // other repos: client role editor -> push allowed
+
+        @Test
+        internal fun namespace_plus_repo_user_override_on_overridden_repo_push_denied() {
+            setNestedGroups(namespaceGroup, repoUserGroup)
+            setRoles(ROLE_EDITOR)
+            setScope(SCOPE_REPO_NAMESPACE_PUSH)
+            assertEmptyAccessItems()
+        }
+
+        @Test
+        internal fun namespace_plus_repo_user_override_on_other_repo_push_allowed() {
+            setNestedGroups(namespaceGroup, repoUserGroup)
+            setRoles(ROLE_EDITOR)
+            setScope("repository:$NAMESPACE/otherrepo:push")
+            assertContainsOneAccessItemWithActions(ACTION_PUSH)
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Repo override only (no namespace group)
+    // Access granted only on specific repo, denied everywhere else
+    // -------------------------------------------------------------------------
+
+    @Nested
+    inner class RepoOverrideOnlyWithoutNamespaceGroupTests {
+
+        @Test
+        internal fun repo_override_only_editor_on_overridden_repo_all() {
+            setNestedGroups(repoEditorGroup)
+            setRoles(ROLE_USER)
+            setScope(SCOPE_REPO_NAMESPACE_ALL)
+            assertContainsOneAccessItemWithActions(ACTION_PULL, ACTION_PUSH, ACTION_DELETE)
+        }
+
+        @Test
+        internal fun repo_override_only_editor_on_overridden_repo_push() {
+            setNestedGroups(repoEditorGroup)
+            setRoles(ROLE_USER)
+            setScope(SCOPE_REPO_NAMESPACE_PUSH)
+            assertContainsOneAccessItemWithActions(ACTION_PUSH)
+        }
+
+        @Test
+        internal fun repo_override_only_editor_on_other_repo_denied() {
+            setNestedGroups(repoEditorGroup)
+            setRoles(ROLE_USER)
+            setScope("repository:$NAMESPACE/otherrepo:pull")
+            assertEmptyAccessItems()
+        }
+
+        @Test
+        internal fun repo_override_only_editor_on_other_namespace_denied() {
+            setNestedGroups(repoEditorGroup)
+            setRoles(ROLE_USER)
+            setScope("repository:othernamespace/$NAMESPACE:pull")
+            assertEmptyAccessItems()
+        }
+
+        @Test
+        internal fun repo_override_only_user_on_overridden_repo_pull() {
+            setNestedGroups(repoUserGroup)
+            setRoles(ROLE_EDITOR)
+            setScope(SCOPE_REPO_NAMESPACE_PULL)
+            assertContainsOneAccessItemWithActions(ACTION_PULL)
+        }
+
+        @Test
+        internal fun repo_override_only_user_on_overridden_repo_push_denied() {
+            setNestedGroups(repoUserGroup)
+            setRoles(ROLE_EDITOR)
+            setScope(SCOPE_REPO_NAMESPACE_PUSH)
+            assertEmptyAccessItems()
+        }
+
+        @Test
+        internal fun repo_override_only_user_on_other_repo_denied() {
+            setNestedGroups(repoUserGroup)
+            setRoles(ROLE_EDITOR)
+            setScope("repository:$NAMESPACE/otherrepo:push")
+            assertEmptyAccessItems()
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Deep repo paths (namespace/team/image)
+    // -------------------------------------------------------------------------
+
+    @Nested
+    inner class DeepRepoPathTests {
+
+        @Test
+        internal fun deep_repo_editor_override_on_scope_all() {
+            setNestedGroups(deepRepoEditorGroup)
+            setRoles(ROLE_USER)
+            setScope(SCOPE_DEEP_REPO_ALL)
+            assertContainsOneAccessItemWithActions(ACTION_PULL, ACTION_PUSH, ACTION_DELETE)
+        }
+
+        @Test
+        internal fun deep_repo_editor_override_on_scope_push() {
+            setNestedGroups(deepRepoEditorGroup)
+            setRoles(ROLE_USER)
+            setScope(SCOPE_DEEP_REPO_PUSH)
+            assertContainsOneAccessItemWithActions(ACTION_PUSH)
+        }
+
+        @Test
+        internal fun deep_repo_editor_override_on_scope_delete() {
+            setNestedGroups(deepRepoEditorGroup)
+            setRoles(ROLE_USER)
+            setScope(SCOPE_DEEP_REPO_DELETE)
+            assertContainsOneAccessItemWithActions(ACTION_DELETE)
+        }
+
+        @Test
+        internal fun deep_repo_editor_override_on_scope_pull_push() {
+            setNestedGroups(deepRepoEditorGroup)
+            setRoles(ROLE_USER)
+            setScope(SCOPE_DEEP_REPO_PULL_PUSH)
+            assertContainsOneAccessItemWithActions(ACTION_PULL, ACTION_PUSH)
+        }
+
+        @Test
+        internal fun deep_repo_editor_does_not_match_shallow_repo() {
+            // group is for "johnny/team/image" but scope requests "johnny/image"
+            setNestedGroups(deepRepoEditorGroup)
+            setRoles(ROLE_USER)
+            setScope(SCOPE_REPO_NAMESPACE_PULL)
+            assertEmptyAccessItems()
+        }
+
+        @Test
+        internal fun deep_repo_user_override_on_scope_pull() {
+            setNestedGroups(deepRepoUserGroup)
+            setRoles(ROLE_EDITOR)
+            setScope(SCOPE_DEEP_REPO_PULL)
+            assertContainsOneAccessItemWithActions(ACTION_PULL)
+        }
+
+        @Test
+        internal fun deep_repo_user_override_on_scope_push_denied() {
+            setNestedGroups(deepRepoUserGroup)
+            setRoles(ROLE_EDITOR)
+            setScope(SCOPE_DEEP_REPO_PUSH)
+            assertEmptyAccessItems()
+        }
+
+        @Test
+        internal fun deep_repo_editor_with_namespace_group_on_deep_repo_push() {
+            setNestedGroups(namespaceGroup, deepRepoEditorGroup)
+            setRoles(ROLE_USER)
+            setScope(SCOPE_DEEP_REPO_PUSH)
+            assertContainsOneAccessItemWithActions(ACTION_PUSH)
+        }
+
+        @Test
+        internal fun deep_repo_editor_with_namespace_group_shallow_repo_falls_back_to_client_role() {
+            // deep override doesn't affect shallow repo -> client role user -> pull only
+            setNestedGroups(namespaceGroup, deepRepoEditorGroup)
+            setRoles(ROLE_USER)
+            setScope(SCOPE_REPO_NAMESPACE_PUSH)
+            assertEmptyAccessItems()
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // No matching group -> deny
+    // -------------------------------------------------------------------------
+
+    @Nested
+    inner class NoMatchingGroupTests {
+
+        @Test
+        internal fun no_groups_denied() {
+            setScope(SCOPE_REPO_NAMESPACE_PULL)
+            assertEmptyAccessItems()
+        }
+
+        @Test
+        internal fun wrong_namespace_repo_override_denied() {
+            setNestedGroups("${prefix}othernamespace/$IMAGE/editor")
+            setRoles(ROLE_EDITOR)
+            setScope(SCOPE_REPO_NAMESPACE_PULL)
+            assertEmptyAccessItems()
+        }
+
+        @Test
+        internal fun wrong_repo_override_denied() {
+            setNestedGroups(otherRepoEditorGroup)
+            setRoles(ROLE_USER)
+            setScope(SCOPE_REPO_NAMESPACE_PULL)
+            assertEmptyAccessItems()
+        }
+    }
+}


### PR DESCRIPTION
Registry permissions can now be overridden by keycloak sub-groups.

e.g. if registry user holds client-role "user", he can retrieve push+delete actions by adding him to this group:

- registry-mycompany
  -  myrepository
     - editor 